### PR TITLE
feat: Add trim_doctest_flag to google and numpy parsers

### DIFF
--- a/docs/docstrings.md
+++ b/docs/docstrings.md
@@ -110,6 +110,8 @@ Yields           | ✅     | [❌][issue-xref-numpy-yields]           | [❌][is
 Option                     | Google | Numpy                                 | Sphinx
 -------------------------- | ------ | ------------------------------------- | ------
 Ignore `__init__` summary  | ✅     | [❌][issue-ignore-init-summary-numpy] | [❌][issue-ignore-init-summary-sphinx]
+Trim doctest flags         | ✅     | ✅                                    | [❌][issue-trim-doctest-flags-sphinx]
 
 [issue-ignore-init-summary-numpy]: https://github.com/mkdocstrings/griffe/issues/44
 [issue-ignore-init-summary-sphinx]: https://github.com/mkdocstrings/griffe/issues/45
+[issue-trim-doctest-flags-sphinx]: https://github.com/mkdocstrings/griffe/issues/49

--- a/src/griffe/docstrings/google.py
+++ b/src/griffe/docstrings/google.py
@@ -32,7 +32,7 @@ _section_kind = {
     "params": DocstringSectionKind.parameters,
     "parameters": DocstringSectionKind.parameters,
     "keyword args": DocstringSectionKind.other_parameters,
-    "keyword parameters": DocstringSectionKind.other_parameters,
+    "keyword arguments": DocstringSectionKind.other_parameters,
     "other args": DocstringSectionKind.other_parameters,
     "other parameters": DocstringSectionKind.other_parameters,
     "raises": DocstringSectionKind.raises,


### PR DESCRIPTION
Related to: https://github.com/mkdocstrings/mkdocstrings/issues/386
Porting the work done on the legacy handler (PR: https://github.com/mkdocstrings/pytkdocs/pull/134) over to griffe.

## Key PR pointers

* ❗️feat: I added in `example` as a section_kind, in addition to `examples` for both Google and Numpy. This is aligned with `pytkdocs` and also accepted by [Sphinx Napoleon](https://www.sphinx-doc.org/en/master/usage/extensions/napoleon.html#docstring-sections). Though I understand, the official Google/Numpy docs don't seem to be explicit about whether `example` is a valid title. Let me know if there was a conscious decision made to not include "example" in Griffe before --- I'll remove it from this PR.
* ❗️fix: I renamed the `keyword_parameters` in the `section_kind` dict; I presume this was a typo since I don't think keyword params is a thing.
* Feat: Implemented the functionality of removal of `# doctest:` and `<BLANKLINE>` via regex; in *both* cases where 1. line starts with `>>>` and 2. line is "in a code example block". This is activated via the new `trim_doctest_flags` parameter / option.
* As mentioned in the parent issue, I have set the default behaviour of `trim_doctest_flags` to be True. To keep consistent with Sphinx.
* Only implemented for Google and Numpy for now.
* Tests: Added test to check behaviour of `trim_doctest_flags` is as intended. (both when it is turned on, and turned off)
* Docs: Updated to reflect the new option. (Will raise a new issue for Sphinx missing `trim_doctest_flags` after this).


❗️About the implementation of the new parser option (and parser options **in general**). Because `trim_doctest_flags` option is only applicable to the examples section, the way I see it, there are 2 ways to go about the implementation.
Option 1 (naive way) is just adding simple if-else in the main `parse` while loop:
```python                                                                                                                               
def _read_examples_section(docstring, offset, trim_doctest_flags=True):                                                    
    # Add the `trim_doctest_flags` as a specific kwarg in this reader function.
    # All the other `_read_xxx` functions remain untouched. 
                                                                                                                                         
def parse(..., trim_doctest_flags=True, **options):                                                                                     
    # ...                                                                                                                                 
    if admonition_type.lower() == 'examples':                                                                                             
        sections, offset =  reader(docstring, offset + 1, trim_doctest_flags)
    else:
        sections, offset = reader(docstring, offset + 1)
 ```                                                                                                                                     
The alternative is what I am proposing in this PR. Make all `_read_xxx` functions accept arbitrary `options` kwargs.
And each reader function is responsible for extracting out the options that they need.

I think the latter is cleaner, especially if we need to extend to other options that might only apply in other sections but not examples, etc. Let me know if this is okay or if you have any better ideas.
