### PR TITLE
Allow named sections after numpy examples

### DIFF
--- a/src/griffe/docstrings/numpy.py
+++ b/src/griffe/docstrings/numpy.py
@@ -157,7 +157,7 @@ def _read_block_items(docstring: Docstring, offset: int) -> tuple[list[list[str]
     return items, index - 1
 
 
-def _read_block(docstring: Docstring, offset: int) -> tuple[str, int]:
+def _read_block(docstring: Docstring, offset: int) -> tuple[str, int]:  # noqa: WPS231
     lines = docstring.lines
     if offset >= len(lines):
         return "", offset
@@ -168,8 +168,14 @@ def _read_block(docstring: Docstring, offset: int) -> tuple[str, int]:
     # skip first empty lines
     while _is_empty_line(lines[index]):
         index += 1
+    while index < len(lines):
+        is_empty = _is_empty_line(lines[index])
+        if is_empty and _is_dash_line(lines[index + 1]):
+            break  # Break if a new unnamed section is reached.
 
-    while index < len(lines) and not (_is_empty_line(lines[index]) and _is_dash_line(lines[index + 1])):
+        if is_empty and index < len(lines) + 1 and _is_dash_line(lines[index + 2]):
+            break  # Break if a new named section is reached.
+
         block.append(lines[index])
         index += 1
 

--- a/tests/test_docstrings/test_numpy.py
+++ b/tests/test_docstrings/test_numpy.py
@@ -382,6 +382,24 @@ def test_examples_section(parse_numpy):
     assert examples.value[3][1].startswith(">>> a = 0  # doctest: +SKIP")
 
 
+def test_examples_section_when_followed_by_named_section(parse_numpy):
+    """Parse examples section."""
+    docstring = """
+        Examples
+        --------
+        Hello, hello.
+
+        Parameters
+        ----------
+        foo : int
+    """
+
+    sections, _ = parse_numpy(docstring, trim_doctest_flags=False)
+    assert len(sections) == 2
+    assert sections[0].kind is DocstringSectionKind.examples
+    assert sections[1].kind is DocstringSectionKind.parameters
+
+
 # =============================================================================================
 # Annotations
 def test_prefer_docstring_type_over_annotation(parse_numpy):

--- a/tests/test_docstrings/test_numpy.py
+++ b/tests/test_docstrings/test_numpy.py
@@ -383,7 +383,11 @@ def test_examples_section(parse_numpy):
 
 
 def test_examples_section_when_followed_by_named_section(parse_numpy):
-    """Parse examples section."""
+    """Parse examples section.
+
+    Parameters:
+        parse_numpy: Parse function (fixture).
+    """
     docstring = """
         Examples
         --------


### PR DESCRIPTION
This is an attempt at fixing the current behaviour where numpydoc `Examples` sections would erroneously include the content of any following named sections until they reach an unnamed section or the end of the docstring.

