### PR TITLE
fix: retrieve default value for non-string parameters

### DIFF
--- a/src/griffe/agents/nodes.py
+++ b/src/griffe/agents/nodes.py
@@ -535,6 +535,7 @@ if sys.version_info < (3, 8):
         """
         return {elt.s for elt in node.value.elts}  # type: ignore[attr-defined]
 
+
 else:
 
     def parse__all__(node: NodeAssign) -> set[str]:  # noqa: WPS116,WPS120,WPS440
@@ -1186,12 +1187,9 @@ def get_parameter_default(node: AST, filepath: Path, lines_collection: LinesColl
     """
     if node is None:
         return None
-    if isinstance(node, NodeConstant):
-        return repr(node.value)
-    if isinstance(node, NodeStr):
-        return repr(node.s)
-    if isinstance(node, NodeName):
-        return node.id
+    value_to_str = _node_value_map.get(type(node), None)
+    if value_to_str is not None:
+        return value_to_str(node)
     if node.lineno == node.end_lineno:  # type: ignore[attr-defined]
         return lines_collection[filepath][node.lineno - 1][node.col_offset : node.end_col_offset]  # type: ignore[attr-defined]
     # TODO: handle multiple line defaults

--- a/src/griffe/agents/nodes.py
+++ b/src/griffe/agents/nodes.py
@@ -1,6 +1,7 @@
 """This module contains utilities for extracting information from nodes."""
 
 from __future__ import annotations
+from contextlib import suppress
 
 import enum
 import inspect
@@ -1187,9 +1188,8 @@ def get_parameter_default(node: AST, filepath: Path, lines_collection: LinesColl
     """
     if node is None:
         return None
-    value_to_str = _node_value_map.get(type(node), None)
-    if value_to_str is not None:
-        return value_to_str(node)
+    with suppress(KeyError):
+        return get_value(node)
     if node.lineno == node.end_lineno:  # type: ignore[attr-defined]
         return lines_collection[filepath][node.lineno - 1][node.col_offset : node.end_col_offset]  # type: ignore[attr-defined]
     # TODO: handle multiple line defaults

--- a/src/griffe/agents/nodes.py
+++ b/src/griffe/agents/nodes.py
@@ -1,7 +1,6 @@
 """This module contains utilities for extracting information from nodes."""
 
 from __future__ import annotations
-from contextlib import suppress
 
 import enum
 import inspect
@@ -71,6 +70,7 @@ from ast import alias as NodeAlias
 from ast import arguments as NodeArguments
 from ast import comprehension as NodeComprehension
 from ast import keyword as NodeKeyword
+from contextlib import suppress
 from functools import partial
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable, Sequence, Type
@@ -535,7 +535,6 @@ if sys.version_info < (3, 8):
             A set of names.
         """
         return {elt.s for elt in node.value.elts}  # type: ignore[attr-defined]
-
 
 else:
 

--- a/src/griffe/collections.py
+++ b/src/griffe/collections.py
@@ -44,7 +44,7 @@ class LinesCollection:
         return getattr(self._data, name, default)
 
     # TODO: remove once Python 3.7 support is dropped
-    @lru_cache(maxsize=None)
+    @lru_cache(maxsize=None)  # noqa: B019
     def tokens(self, path: Path) -> tuple[list[tokenize.TokenInfo], defaultdict]:
         """Tokenize the code.
 

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -71,3 +71,28 @@ def test_building_annotations_from_nodes(expression):
         assert "y" in module.members
         assert str(module["x"].annotation) == expression
         assert str(module["y"].annotation) == expression
+
+
+@pytest.mark.parametrize(
+    "default",
+    [
+        1,
+        "'test_string'",
+        dict(key=1),
+        {"key": 1},
+        "DEFAULT_VALUE",
+        None,
+    ],
+)
+def test_default_value_from_nodes(default):
+    """Test getting default value from AST nodes.
+
+    Parameters:
+        default: A default value (parametrized).
+    """
+    module_defs = f"def f(x={default}):\n    return x" ""
+    with temporary_visited_module(module_defs) as module:
+        assert "f" in module.members
+        params = module.members["f"].parameters
+        assert len(params) == 1
+        assert params[0].default == str(default)

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -76,12 +76,12 @@ def test_building_annotations_from_nodes(expression):
 @pytest.mark.parametrize(
     "default",
     [
-        1,
+        "1",
         "'test_string'",
-        dict(key=1),
-        {"key": 1},
+        "dict(key=1)",
+        "{'key': 1}",
         "DEFAULT_VALUE",
-        None,
+        "None",
     ],
 )
 def test_default_value_from_nodes(default):
@@ -90,9 +90,9 @@ def test_default_value_from_nodes(default):
     Parameters:
         default: A default value (parametrized).
     """
-    module_defs = f"def f(x={default}):\n    return x" ""
+    module_defs = f"def f(x={default}):\n    return x"
     with temporary_visited_module(module_defs) as module:
         assert "f" in module.members
         params = module.members["f"].parameters
         assert len(params) == 1
-        assert params[0].default == str(default)
+        assert params[0].default == default


### PR DESCRIPTION
Should solve #59 and [this issue](https://github.com/mkdocstrings/python/issues/8) from `mkdocstrings-python`