### PR TITLE
tests: Fix CLI Test on Windows

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -9,7 +9,7 @@ from griffe import cli
 
 def test_main():
     """Basic CLI test."""
-    if sys.platform == 'windows':
+    if sys.platform == 'win32':
         assert cli.main(["griffe", "-s", "src", "-oNUL"]) == 0
     else:
         assert cli.main(["griffe", "-s", "src", "-o/dev/null"]) == 0

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,5 +1,7 @@
 """Tests for the `cli` module."""
 
+import sys
+
 import pytest
 
 from griffe import cli
@@ -7,7 +9,10 @@ from griffe import cli
 
 def test_main():
     """Basic CLI test."""
-    assert cli.main(["griffe", "-s", "src", "-o/dev/null"]) == 0
+    if sys.platform == 'windows':
+        assert cli.main(["griffe", "-s", "src", "-oNUL"]) == 0
+    else:
+        assert cli.main(["griffe", "-s", "src", "-o/dev/null"]) == 0
 
 
 def test_show_help(capsys):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -9,7 +9,7 @@ from griffe import cli
 
 def test_main():
     """Basic CLI test."""
-    if sys.platform == 'win32':
+    if sys.platform == "win32":
         assert cli.main(["griffe", "-s", "src", "-oNUL"]) == 0
     else:
         assert cli.main(["griffe", "-s", "src", "-o/dev/null"]) == 0


### PR DESCRIPTION
Changed the output path of CLI test on Windows to a similar path. 

This should fix the Windows build error as I patched it similarly here on the `conda-forge` Windows test 👍 : https://github.com/conda-forge/griffe-feedstock/blob/befe014bfac10bb45a46ad7e19d598c34e53db99/recipe/patches/0001-windows-cli-test-patch.patch

> Reference: 
> https://stackoverflow.com/questions/313111/is-there-a-dev-null-on-windows
> https://stackoverflow.com/questions/446209/possible-values-from-sys-platform