### PR TITLE
feat: add to/from_json convenience methods to Object

### DIFF
--- a/src/griffe/cli.py
+++ b/src/griffe/cli.py
@@ -315,7 +315,7 @@ def main(args: list[str] | None = None) -> int:  # noqa: WPS231
     started = datetime.now()
     if per_package_output:
         for package_name, data in packages.items():
-            serialized = data.as_json(full=opts.full)
+            serialized = data.as_json(indent=2, full=opts.full)
             _print_data(serialized, output.format(package=package_name))
     else:
         serialized = json.dumps(packages, cls=JSONEncoder, indent=2, full=opts.full)

--- a/src/griffe/cli.py
+++ b/src/griffe/cli.py
@@ -315,7 +315,7 @@ def main(args: list[str] | None = None) -> int:  # noqa: WPS231
     started = datetime.now()
     if per_package_output:
         for package_name, data in packages.items():
-            serialized = json.dumps(data, cls=JSONEncoder, indent=2, full=opts.full)
+            serialized = data.as_json(full=opts.full)
             _print_data(serialized, output.format(package=package_name))
     else:
         serialized = json.dumps(packages, cls=JSONEncoder, indent=2, full=opts.full)

--- a/src/griffe/dataclasses.py
+++ b/src/griffe/dataclasses.py
@@ -8,28 +8,25 @@ from __future__ import annotations
 
 import enum
 import inspect
-import json
 import sys
 from collections import defaultdict
 from contextlib import suppress
 from pathlib import Path
 from textwrap import dedent
-from typing import Any, Callable, Type, TypeVar, cast
+from typing import Any, Callable, cast
 
 from griffe.collections import LinesCollection, ModulesCollection
 from griffe.docstrings.dataclasses import DocstringSection
 from griffe.docstrings.parsers import Parser, parse  # noqa: WPS347
 from griffe.exceptions import AliasResolutionError, BuiltinModuleError, CyclicAliasError, NameResolutionError
 from griffe.expressions import Expression, Name
-from griffe.mixins import GetMembersMixin, ObjectAliasMixin, SetMembersMixin
+from griffe.mixins import GetMembersMixin, ObjectAliasMixin, SetMembersMixin, SerializationMixin
 
 # TODO: remove once Python 3.7 support is dropped
 if sys.version_info < (3, 8):
     from cached_property import cached_property
 else:
     from functools import cached_property  # noqa: WPS440
-
-_ObjType = TypeVar("_ObjType")
 
 
 class ParameterKind(enum.Enum):
@@ -290,7 +287,7 @@ class Kind(enum.Enum):
     ALIAS: str = "alias"
 
 
-class Object(GetMembersMixin, SetMembersMixin, ObjectAliasMixin):
+class Object(GetMembersMixin, SetMembersMixin, ObjectAliasMixin, SerializationMixin):  # noqa: WPS215
     """An abstract class representing a Python object.
 
     Attributes:
@@ -722,44 +719,6 @@ class Object(GetMembersMixin, SetMembersMixin, ObjectAliasMixin):
         base["members"] = [member.as_dict(full=full, **kwargs) for member in self.members.values()]
 
         return base
-
-    def as_json(self, full: bool = False, indent: int = 2, **kwargs: Any) -> str:
-        """Return this object's data as a JSON string.
-
-        Parameters:
-            full: Whether to return full info, or just base info.
-            indent: Indentation level for JSON output.
-            **kwargs: Additional serialization options passed to encoder.
-
-        Returns:
-            A string.
-        """
-        from griffe.encoders import JSONEncoder
-
-        return json.dumps(self, cls=JSONEncoder, indent=indent, full=full, **kwargs)
-
-    @classmethod
-    def from_json(cls: Type[_ObjType], json_string: str, **kwargs) -> _ObjType:
-        """Create an instance of this class from a JSON string.
-
-        Parameters:
-            json_string: JSON to decode into Object.
-            **kwargs: Additional options passed to decoder.
-
-        Returns:
-            An Object instance.
-
-        Raises:
-            TypeError: When the json_string does not represent and object
-                       of the class from which this classmethod has been called.
-        """
-        from griffe.encoders import json_decoder
-
-        kwargs.setdefault("object_hook", json_decoder)
-        obj = json.loads(json_string, **kwargs)
-        if not isinstance(obj, cls):
-            raise TypeError(f"provided JSON object is not of type {cls}")
-        return obj
 
     # TODO: remove once Python 3.7 support is dropped
     @property

--- a/src/griffe/mixins.py
+++ b/src/griffe/mixins.py
@@ -138,12 +138,11 @@ class ObjectAliasMixin:
 class SerializationMixin:
     """A mixin that adds de/serialization conveniences."""
 
-    def as_json(self, full: bool = False, indent: int = 2, **kwargs: Any) -> str:
+    def as_json(self, full: bool = False, **kwargs: Any) -> str:
         """Return this object's data as a JSON string.
 
         Parameters:
             full: Whether to return full info, or just base info.
-            indent: Indentation level for JSON output.
             **kwargs: Additional serialization options passed to encoder.
 
         Returns:
@@ -151,10 +150,10 @@ class SerializationMixin:
         """
         from griffe.encoders import JSONEncoder  # avoid circular import
 
-        return json.dumps(self, cls=JSONEncoder, indent=indent, full=full, **kwargs)
+        return json.dumps(self, cls=JSONEncoder, full=full, **kwargs)
 
     @classmethod
-    def from_json(cls: Type[_ObjType], json_string: str, **kwargs) -> _ObjType:
+    def from_json(cls: Type[_ObjType], json_string: str, **kwargs: Any) -> _ObjType:
         """Create an instance of this class from a JSON string.
 
         Parameters:
@@ -166,7 +165,7 @@ class SerializationMixin:
 
         Raises:
             TypeError: When the json_string does not represent and object
-                       of the class from which this classmethod has been called.
+                of the class from which this classmethod has been called.
         """
         from griffe.encoders import json_decoder  # avoid circular import
 

--- a/tests/test_encoders.py
+++ b/tests/test_encoders.py
@@ -1,11 +1,7 @@
 """Tests for the `encoders` module."""
-
-import json
-
 import pytest
 
 from griffe.dataclasses import Function, Module, Object
-from griffe.encoders import JSONEncoder, json_decoder
 from griffe.loader import GriffeLoader
 
 
@@ -18,22 +14,11 @@ def test_minimal_data_is_enough():
     """
     loader = GriffeLoader()
     module = loader.load_module("griffe")
-    minimal = json.dumps(module, cls=JSONEncoder, full=False, indent=2)
-    full = json.dumps(module, cls=JSONEncoder, full=True, indent=2)
-    reloaded = json.loads(minimal, object_hook=json_decoder)
-    assert json.dumps(reloaded, cls=JSONEncoder, full=False, indent=2) == minimal
-    assert json.dumps(reloaded, cls=JSONEncoder, full=True, indent=2) == full
-
-
-def test_object_as_from_json():
-    """Test serialization and de-serialization convenience methods on Object."""
-    loader = GriffeLoader()
-    module = loader.load_module("griffe")
     minimal = module.as_json(full=False, indent=2)
-    assert minimal == json.dumps(module, cls=JSONEncoder, full=False, indent=2)
+    full = module.as_json(full=True, indent=2)
     reloaded = Module.from_json(minimal)
-    # recasting to json for sake of comparison easier than as_dict()
-    assert module.as_json() == reloaded.as_json()
+    assert reloaded.as_json(full=False, indent=2) == minimal
+    assert reloaded.as_json(full=True, indent=2) == full
 
     # also works (but will result in a different type hint)
     assert Object.from_json(minimal)

--- a/tests/test_encoders.py
+++ b/tests/test_encoders.py
@@ -2,6 +2,9 @@
 
 import json
 
+import pytest
+
+from griffe.dataclasses import Function, Module, Object
 from griffe.encoders import JSONEncoder, json_decoder
 from griffe.loader import GriffeLoader
 
@@ -20,3 +23,22 @@ def test_minimal_data_is_enough():
     reloaded = json.loads(minimal, object_hook=json_decoder)
     assert json.dumps(reloaded, cls=JSONEncoder, full=False, indent=2) == minimal
     assert json.dumps(reloaded, cls=JSONEncoder, full=True, indent=2) == full
+
+
+def test_object_as_from_json():
+    """Test serialization and de-serialization convenience methods on Object."""
+    loader = GriffeLoader()
+    module = loader.load_module("griffe")
+    minimal = module.as_json(full=False, indent=2)
+    assert minimal == json.dumps(module, cls=JSONEncoder, full=False, indent=2)
+    reloaded = Module.from_json(minimal)
+    # recasting to json for sake of comparison easier than as_dict()
+    assert module.as_json() == reloaded.as_json()
+
+    # also works (but will result in a different type hint)
+    assert Object.from_json(minimal)
+
+    # Won't work if the JSON doesn't represent the type requested.
+    with pytest.raises(TypeError) as err:
+        Function.from_json(minimal)
+    assert "provided JSON object is not of type" in str(err.value)  # noqa: WPS441

--- a/tests/test_encoders.py
+++ b/tests/test_encoders.py
@@ -14,11 +14,11 @@ def test_minimal_data_is_enough():
     """
     loader = GriffeLoader()
     module = loader.load_module("griffe")
-    minimal = module.as_json(full=False, indent=2)
-    full = module.as_json(full=True, indent=2)
+    minimal = module.as_json(full=False)
+    full = module.as_json(full=True)
     reloaded = Module.from_json(minimal)
-    assert reloaded.as_json(full=False, indent=2) == minimal
-    assert reloaded.as_json(full=True, indent=2) == full
+    assert reloaded.as_json(full=False) == minimal
+    assert reloaded.as_json(full=True) == full
 
     # also works (but will result in a different type hint)
     assert Object.from_json(minimal)


### PR DESCRIPTION
👋

I wonder if you'd consider this PR that adds some serialization/deserialization convenience methods to `dataclasses.Object`.  When using programmatically, it makes it easier to construct/deconstruct from serialized.

I made it a mixin that could be added to other objects (since _many_ of the objects here could theoretically be supported), but I stopped short of adding it to anything besides Object.  (but `ModulesCollection`, for example, would be another prime candidate).

One of the nice things this does is support type hinting:
```python
from griffe.dataclasses import Module

mod = Module.from_json('{...}')
reveal_type(mod)  # type of "mod" is "Module"
```