### PR TITLE
fix: ignore comments in .pth files

### DIFF
--- a/src/griffe/finder.py
+++ b/src/griffe/finder.py
@@ -286,7 +286,7 @@ def _module_depth(name_parts_and_path: NamePartsAndPathType) -> int:
 
 def _handle_pth_file(path):
     # support for .pth files pointing to a directory
-    instructions = path.read_text().strip("\n").split(";")
+    instructions = list(filter(lambda l: not l.strip().startswith("#"), path.read_text().strip("\n").split(";")))
     added_dir = Path(instructions[0])
     if added_dir.exists():
         return added_dir


### PR DESCRIPTION
Fixes https://github.com/mkdocstrings/griffe/issues/84

Had the same issue with pdbpp on OS X, this made the trick.

This is a very naive implementation for single-line comments, feedback welcome.