### PR TITLE
Always use `encoding="utf8"` when reading text files.

### DIFF
--- a/duties.py
+++ b/duties.py
@@ -204,7 +204,7 @@ def check_types(ctx):  # noqa: WPS231
     # handle .pth files
     for pth in pkgs_dir.glob("*.pth"):
         with suppress(OSError):
-            for package in Path(pth.read_text().splitlines()[0]).glob("*"):  # noqa: WPS440
+            for package in Path(pth.read_text(encoding="utf8").splitlines()[0]).glob("*"):  # noqa: WPS440
                 if package.suffix != ".dist-info":
                     packages[package.name] = package
 
@@ -223,7 +223,7 @@ def check_types(ctx):  # noqa: WPS231
                 Path(tmpdir, pkg_name).symlink_to(packages[pkg_name], target_is_directory=True)
 
         # create temporary mypy config to ignore stubbed packages
-        newconfig = Path("config", "mypy.ini").read_text()
+        newconfig = Path("config", "mypy.ini").read_text(encoding="utf8")
         newconfig += "\n" + "\n\n".join(f"[mypy-{pkg}.*]\nignore_errors=true" for pkg in ignore)
         tmpconfig = Path(tmpdir, "mypy.ini")
         tmpconfig.write_text(newconfig)

--- a/src/griffe/finder.py
+++ b/src/griffe/finder.py
@@ -284,7 +284,7 @@ _re_import_line = re.compile(r"^import[ \t]")
 # TODO: for better robustness, we should load and minify the AST
 # to search for particular call statements
 def _is_pkg_style_namespace(init_module: Path) -> bool:
-    code = init_module.read_text()
+    code = init_module.read_text(encoding="utf8")
     return bool(_re_pkgresources.search(code) or _re_pkgutil.search(code))
 
 
@@ -304,7 +304,7 @@ def _handle_pth_file(path) -> list[Path]:  # noqa: WPS231
     # Blank lines and lines beginning with # are skipped.
     # Lines starting with import (followed by space or tab) are executed.
     directories = []
-    for line in path.read_text().strip().splitlines(keepends=False):
+    for line in path.read_text(encoding="utf8").strip().splitlines(keepends=False):
         line = line.strip()
         if line and not line.startswith("#") and not _re_import_line.search(line):
             if os.path.exists(line):
@@ -314,7 +314,7 @@ def _handle_pth_file(path) -> list[Path]:  # noqa: WPS231
 
 def _handle_editables_module(path: Path):
     try:
-        editables_lines = path.read_text().splitlines(keepends=False)
+        editables_lines = path.read_text(encoding="utf8").splitlines(keepends=False)
     except FileNotFoundError:
         raise UnhandledEditablesModuleError(path)
     # example line: F.map_module('griffe', '/media/data/dev/griffe/src/griffe/__init__.py')

--- a/src/griffe/loader.py
+++ b/src/griffe/loader.py
@@ -51,7 +51,7 @@ def _get_async_reader():
         logger.warning("aiofiles is not installed, fallback to blocking read")
 
         async def _read_async(path):  # noqa: WPS430
-            return path.read_text()
+            return path.read_text(encoding="utf8")
 
     else:
 


### PR DESCRIPTION
Closes #99 