### PR TITLE
feat: Add function to find API breaking changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,25 +70,25 @@ See [the Usage section](https://mkdocstrings.github.io/griffe/usage/#with-python
     - Flat JSON
     - JSON schema
 - API diff:
-    - Mecanism to cache APIs? Should users version them, or store them somewhere (docs)?
-    - Ability to return warnings (things that are not backward-compatibility-friendly)
+    - [ ] Mecanism to cache APIs? Should users version them, or store them somewhere (docs)?
+    - [ ] Ability to return warnings (things that are not backward-compatibility-friendly)
     - List of things to consider for warnings
         - Multiple positional-or-keyword parameters
         - Public imports in public modules
         - Private things made public through imports/assignments
         - Too many public things? Generally annoying. Configuration?
-    - Ability to compare two APIs to return breaking changes
+    - [x] Ability to compare two APIs to return breaking changes
     - List of things to consider for breaking changes
-        - Changed position of positional only parameter
-        - Changed position of positional or keyword parameter
-        - Changed type of parameter
-        - Changed type of public module attribute
-        - Changed return type of a public function/method
-        - Added parameter without a default value
-        - Removed keyword-only parameter without a default value, without **kwargs to swallow it
-        - Removed positional-only parameter without a default value, without *args to swallow it
-        - Removed positional-or_keyword argument without a default value, without *args and **kwargs to swallow it
-        - Removed public module/class/function/method/attribute
-        - All of the previous even when parent is private (could be publicly imported or assigned somewhere),
+        - [x] Changed position of positional only parameter
+        - [x] Changed position of positional or keyword parameter
+        - [ ] Changed type of parameter
+        - [ ] Changed type of public module attribute
+        - [ ] Changed return type of a public function/method
+        - [x] Added parameter without a default value
+        - [x] Removed keyword-only parameter without a default value, without **kwargs to swallow it
+        - [x] Removed positional-only parameter without a default value, without *args to swallow it
+        - [x] Removed positional-or_keyword argument without a default value, without *args and **kwargs to swallow it
+        - [x] Removed public module/class/function/method/attribute
+        - [ ] All of the previous even when parent is private (could be publicly imported or assigned somewhere),
             and later be smarter: public assign/import makes private things public!
-        - Inheritance: removed base, or added/changed base that changes MRO
+        - [ ] Inheritance: removed, added or changed base that changes MRO

--- a/config/flake8.ini
+++ b/config/flake8.ini
@@ -131,6 +131,7 @@ ignore =
 
 per-file-ignores =
     src/griffe/dataclasses.py:WPS115
+    src/griffe/diff.py:WPS115
     src/griffe/agents/nodes.py:WPS115,WPS116,WPS120
     src/griffe/visitor.py:N802,D102
     src/griffe/encoders.py:WPS232

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ classifiers = [
 ]
 dependencies = [
     "cached-property; python_version < '3.8'",
+    "colorama>=0.4",
 ]
 
 [project.optional-dependencies]

--- a/src/griffe/__init__.py
+++ b/src/griffe/__init__.py
@@ -6,6 +6,8 @@ Extract the structure, the frame, the skeleton of your project,
 to generate API documentation or find breaking changes in your API.
 """
 
+from griffe.diff import find_breaking_changes
+from griffe.git import load_git
 from griffe.loader import load  # noqa: WPS347
 
-__all__ = ["load"]
+__all__ = ["find_breaking_changes", "load", "load_git"]

--- a/src/griffe/agents/visitor.py
+++ b/src/griffe/agents/visitor.py
@@ -378,7 +378,7 @@ class Visitor(BaseVisitor):  # noqa: WPS338
             annotation = safe_get_annotation(node.args.vararg.annotation, parent=self.current)
             parameters.add(
                 Parameter(
-                    f"*{node.args.vararg.arg}",
+                    node.args.vararg.arg,
                     annotation=annotation,
                     kind=ParameterKind.var_positional,
                     default="()",
@@ -408,7 +408,7 @@ class Visitor(BaseVisitor):  # noqa: WPS338
             annotation = safe_get_annotation(node.args.kwarg.annotation, parent=self.current)
             parameters.add(
                 Parameter(
-                    f"**{node.args.kwarg.arg}",
+                    node.args.kwarg.arg,
                     annotation=annotation,
                     kind=ParameterKind.var_keyword,
                     default="{}",  # noqa: P103

--- a/src/griffe/cli.py
+++ b/src/griffe/cli.py
@@ -17,19 +17,25 @@ import argparse
 import json
 import logging
 import os
+import subprocess  # noqa: S404
 import sys
 from datetime import datetime
 from pathlib import Path
-from typing import IO, Any, Sequence, Type
+from typing import IO, Any, Callable, Sequence, Type
+
+import colorama
 
 from griffe.agents.extensions import Extension, Extensions
 from griffe.agents.extensions.base import load_extensions
+from griffe.diff import ExplanationStyle, find_breaking_changes
 from griffe.docstrings.parsers import Parser
 from griffe.encoders import JSONEncoder
 from griffe.exceptions import ExtensionError
-from griffe.loader import GriffeLoader
+from griffe.git import load_git
+from griffe.loader import GriffeLoader, load  # noqa: WPS347
 from griffe.logger import get_logger
 
+DEFAULT_LOG_LEVEL = os.getenv("GRIFFE_LOG_LEVEL", "INFO").upper()
 logger = get_logger(__name__)
 
 
@@ -41,6 +47,30 @@ def _print_data(data: str, output_file: str | IO | None):
         if output_file is None:
             output_file = sys.stdout
         print(data, file=output_file)
+
+
+def _get_latest_tag(path: str | Path) -> str:
+    if isinstance(path, str):
+        path = Path(path)
+    if not path.is_dir():
+        path = path.parent
+    output = subprocess.check_output(  # noqa: S603,S607
+        ["git", "describe", "--tags", "--abbrev=0"],
+        cwd=path,
+    )
+    return output.decode().strip()
+
+
+def _get_repo_root(path: str | Path) -> str:
+    if isinstance(path, str):
+        path = Path(path)
+    if not path.is_dir():
+        path = path.parent
+    output = subprocess.check_output(  # noqa: S603,S607
+        ["git", "rev-parse", "--show-toplevel"],
+        cwd=path,
+    )
+    return output.decode().strip()
 
 
 def _stats(stats):
@@ -114,7 +144,7 @@ def _load_packages(
     resolve_implicit: bool = False,
     resolve_external: bool = False,
     allow_inspection: bool = True,
-):
+) -> GriffeLoader:
     loader = GriffeLoader(
         extensions=extensions,
         search_paths=search_paths,
@@ -177,13 +207,6 @@ def get_parser() -> argparse.ArgumentParser:
             type=Path,
             help="Paths to search packages into.",
         )
-        search_options.add_argument(
-            "-y",
-            "--sys-path",
-            dest="append_sys_path",
-            action="store_true",
-            help="Whether to append sys.path to search paths specified with -s.",
-        )
         loading_options = subparser.add_argument_group(title="Loading options")
         loading_options.add_argument(
             "-e",
@@ -193,25 +216,6 @@ def get_parser() -> argparse.ArgumentParser:
             help="A list of extensions to use.",
         )
         loading_options.add_argument(
-            "-r",
-            "--resolve-aliases",
-            action="store_true",
-            help="Whether to resolve aliases.",
-        )
-        loading_options.add_argument(
-            "-I",
-            "--resolve-implicit",
-            action="store_true",
-            help="Whether to resolve implicitely exported aliases as well. "
-            "Aliases are explicitely exported when defined in '__all__'.",
-        )
-        loading_options.add_argument(
-            "-U",
-            "--resolve-external",
-            action="store_true",
-            help="Whether to resolve aliases pointing to external/unknown modules (not loaded directly).",
-        )
-        loading_options.add_argument(
             "-X",
             "--no-inspection",
             dest="allow_inspection",
@@ -219,42 +223,21 @@ def get_parser() -> argparse.ArgumentParser:
             default=True,
             help="Disallow inspection of builtin/compiled/not found modules.",
         )
-        docstring_options = subparser.add_argument_group(title="Docstrings options")
-        docstring_options.add_argument(
-            "-d",
-            "--docstyle",
-            dest="docstring_parser",
-            default=None,
-            type=Parser,
-            help="The docstring style to parse.",
-        )
-        docstring_options.add_argument(
-            "-D",
-            "--docopts",
-            dest="docstring_options",
-            default={},
-            type=json.loads,
-            help="The options for the docstring parser.",
-        )
         debug_options = subparser.add_argument_group(title="Debugging options")
         debug_options.add_argument(
             "-L",
             "--log-level",
             metavar="LEVEL",
-            default=os.getenv("GRIFFE_LOG_LEVEL", "INFO").upper(),
+            default=DEFAULT_LOG_LEVEL,
             choices=_level_choices,
             type=str.upper,
             help="Set the log level: DEBUG, INFO, WARNING, ERROR, CRITICAL.",
         )
-        debug_options.add_argument(
-            "-S",
-            "--stats",
-            action="store_true",
-            help="Show statistics at the end.",
-        )
 
     # ========= SUBPARSERS ========= #
-    subparsers = parser.add_subparsers(dest="subcommand", title="Commands", metavar="", prog="griffe")
+    subparsers = parser.add_subparsers(
+        dest="subcommand", title="Commands", metavar="COMMAND", prog="griffe", required=True
+    )
 
     def add_subparser(command: str, text: str, **kwargs) -> argparse.ArgumentParser:  # noqa: WPS430 (nested function)
         return subparsers.add_parser(command, add_help=False, help=text, description=text, **kwargs)
@@ -276,7 +259,74 @@ def get_parser() -> argparse.ArgumentParser:
         default=sys.stdout,
         help="Output file. Supports templating to output each package in its own file, with {package}.",
     )
+    dump_options.add_argument(
+        "-d",
+        "--docstyle",
+        dest="docstring_parser",
+        default=None,
+        type=Parser,
+        help="The docstring style to parse.",
+    )
+    dump_options.add_argument(
+        "-D",
+        "--docopts",
+        dest="docstring_options",
+        default={},
+        type=json.loads,
+        help="The options for the docstring parser.",
+    )
+    dump_options.add_argument(
+        "-y",
+        "--sys-path",
+        dest="append_sys_path",
+        action="store_true",
+        help="Whether to append sys.path to search paths specified with -s.",
+    )
+    dump_options.add_argument(
+        "-r",
+        "--resolve-aliases",
+        action="store_true",
+        help="Whether to resolve aliases.",
+    )
+    dump_options.add_argument(
+        "-I",
+        "--resolve-implicit",
+        action="store_true",
+        help="Whether to resolve implicitely exported aliases as well. "
+        "Aliases are explicitely exported when defined in '__all__'.",
+    )
+    dump_options.add_argument(
+        "-U",
+        "--resolve-external",
+        action="store_true",
+        help="Whether to resolve aliases pointing to external/unknown modules (not loaded directly).",
+    )
+    dump_options.add_argument(
+        "-S",
+        "--stats",
+        action="store_true",
+        help="Show statistics at the end.",
+    )
     add_common_options(dump_parser)
+
+    # ========= CHECK PARSER ========= #
+    check_parser = add_subparser("check", "Check for API breakages or possible improvements.")
+    check_options = check_parser.add_argument_group(title="Check options")
+    check_options.add_argument("package", metavar="PACKAGE", help="Package to find, load and check, as path.")
+    check_options.add_argument(
+        "-a",
+        "--against",
+        metavar="REF",
+        help="Older Git reference (commit, branch, tag) to check against. Default: load latest tag.",
+    )
+    check_options.add_argument(
+        "-b",
+        "--base-ref",
+        metavar="BASE_REF",
+        help="Git reference (commit, branch, tag) to check. Default: load current code.",
+    )
+    check_options.add_argument("-v", "--verbose", action="store_true", help="Verbose output.")
+    add_common_options(check_parser)
 
     return parser
 
@@ -360,6 +410,85 @@ def dump(
     return 0 if len(data_packages) == len(packages) else 1
 
 
+def check(
+    package: str | Path,
+    against: str | None = None,
+    against_path: str | Path | None = None,
+    *,
+    base_ref: str | None = None,
+    extensions: Sequence[str | dict[str, Any] | Extension | Type[Extension]] | None = None,
+    search_paths: Sequence[str | Path] | None = None,
+    allow_inspection: bool = True,
+    verbose: bool = False,
+) -> int:
+    """Load packages data and dump it as JSON.
+
+    Parameters:
+        package: The package to load and check.
+        against: Older Git reference (commit, branch, tag) to check against.
+        against_path: Path when the "against" reference is checked out.
+        base_ref: Git reference (commit, branch, tag) to check.
+        extensions: The extensions to use.
+        search_paths: The paths to search into.
+        allow_inspection: Whether to allow inspecting modules when visiting them is not possible.
+        verbose: Use a verbose output.
+
+    Returns:
+        `0` for success, `1` for failure.
+    """
+    colorama.deinit()
+    colorama.init()
+
+    search_paths = list(search_paths) if search_paths else []
+
+    against = against or _get_latest_tag(package)
+    against_path = against_path or package
+    repository = _get_repo_root(against_path)
+
+    try:
+        loaded_extensions = load_extensions(extensions or ())
+    except ExtensionError as error:
+        logger.error(error)
+        return 1
+
+    old_package = load_git(
+        against_path,
+        commit=against,
+        repo=repository,
+        extensions=loaded_extensions,
+        search_paths=search_paths,
+        allow_inspection=allow_inspection,
+    )
+    if base_ref:
+        new_package = load_git(
+            package,
+            commit=base_ref,
+            repo=repository,
+            extensions=loaded_extensions,
+            search_paths=search_paths,
+            allow_inspection=allow_inspection,
+        )
+    else:
+        new_package = load(
+            package,
+            try_relative_path=True,
+            extensions=loaded_extensions,
+            search_paths=search_paths,
+            allow_inspection=allow_inspection,
+        )
+
+    if verbose:
+        style = ExplanationStyle.VERBOSE
+    else:
+        style = ExplanationStyle.ONE_LINE
+    breakages = list(find_breaking_changes(old_package, new_package))
+    for breakage in breakages:
+        print(breakage.explain(style=style), file=sys.stderr)
+    if breakages:
+        return 1
+    return 0
+
+
 def main(args: list[str] | None = None) -> int:  # noqa: WPS231
     """Run the main program.
 
@@ -376,7 +505,7 @@ def main(args: list[str] | None = None) -> int:  # noqa: WPS231
     opts_dict = opts.__dict__
     subcommand = opts_dict.pop("subcommand")
 
-    log_level = opts_dict.pop("log_level")
+    log_level = opts_dict.pop("log_level", DEFAULT_LOG_LEVEL)
     try:
         level = getattr(logging, log_level)
     except AttributeError:
@@ -389,4 +518,5 @@ def main(args: list[str] | None = None) -> int:  # noqa: WPS231
     else:
         logging.basicConfig(format="%(levelname)-10s %(message)s", level=level)  # noqa: WPS323
 
-    return {"dump": dump}[subcommand](**opts_dict)
+    commands: dict[str, Callable[..., int]] = {"check": check, "dump": dump}
+    return commands[subcommand](**opts_dict)

--- a/src/griffe/dataclasses.py
+++ b/src/griffe/dataclasses.py
@@ -258,7 +258,7 @@ class Parameters:
     def __getitem__(self, name_or_index: int | str) -> Parameter:
         if isinstance(name_or_index, int):
             return self._parameters_list[name_or_index]
-        return self._parameters_dict[name_or_index]
+        return self._parameters_dict[name_or_index.lstrip("*")]
 
     def __len__(self):
         return len(self._parameters_list)
@@ -267,7 +267,7 @@ class Parameters:
         return iter(self._parameters_list)
 
     def __contains__(self, param_name: str):
-        return param_name in self._parameters_dict
+        return param_name.lstrip("*") in self._parameters_dict
 
     def add(self, parameter: Parameter) -> None:
         """Add a parameter to the container.

--- a/src/griffe/dataclasses.py
+++ b/src/griffe/dataclasses.py
@@ -206,6 +206,21 @@ class Parameter:
         self.kind: ParameterKind | None = kind
         self.default: str | None = default
 
+    def __str__(self) -> str:
+        param = f"{self.name}: {self.annotation} = {self.default}"
+        if self.kind:
+            return f"[{self.kind.value}] {param}"
+        return param
+
+    @property
+    def required(self) -> bool:
+        """Tell if this parameter is required.
+
+        Returns:
+            True or False.
+        """
+        return self.default is None
+
     def as_dict(self, **kwargs: Any) -> dict[str, Any]:
         """Return this parameter's data as a dictionary.
 

--- a/src/griffe/diff.py
+++ b/src/griffe/diff.py
@@ -1,0 +1,290 @@
+"""This module exports "breaking changes" related utilities."""
+
+from __future__ import annotations
+
+import contextlib
+import enum
+from typing import Any, Iterable, Iterator
+
+from griffe.dataclasses import Alias, Attribute, Class, Function, Object, ParameterKind
+from griffe.logger import get_logger
+
+POSITIONAL = frozenset((ParameterKind.positional_only, ParameterKind.positional_or_keyword))
+KEYWORD = frozenset((ParameterKind.keyword_only, ParameterKind.positional_or_keyword))
+POSITIONAL_KEYWORD_ONLY = frozenset((ParameterKind.positional_only, ParameterKind.keyword_only))
+
+logger = get_logger(__name__)
+
+
+class BreakageKind(enum.Enum):
+    """An enumeration of the possible breakages."""
+
+    PARAMETER_MOVED: str = "Positional parameter was moved"
+    PARAMETER_REMOVED: str = "Parameter was removed"
+    PARAMETER_CHANGED_KIND: str = "Parameter kind was changed"
+    PARAMETER_CHANGED_DEFAULT: str = "Parameter default was changed"
+    PARAMETER_CHANGED_REQUIRED: str = "Parameter is now required"
+    PARAMETER_ADDED_REQUIRED: str = "Parameter was added as required"
+    RETURN_CHANGED_TYPE: str = "Return types are incompatible"
+    OBJECT_REMOVED: str = "Public object was removed"
+    OBJECT_CHANGED_KIND: str = "Public object points to a different kind of object"
+    ATTRIBUTE_CHANGED_TYPE: str = "Attribute types are incompatible"
+    ATTRIBUTE_CHANGED_VALUE: str = "Attribute value was changed"
+    CLASS_REMOVED_BASE: str = "Base class was removed"
+
+
+class Breakage:
+    """Breakages can explain what broke from a version to another."""
+
+    kind: BreakageKind
+
+    def __init__(self, obj: Object, old_value: Any, new_value: Any, details: str = "") -> None:
+        """Initialize the breakage.
+
+        Parameters:
+            obj: The object related to the breakage.
+            old_value: The old value.
+            new_value: The new, incompatible value.
+            details: Some details about the breakage.
+        """
+        self.obj = obj
+        self.old_value = old_value
+        self.new_value = new_value
+        self.details = details
+
+    def __str__(self) -> str:
+        return f"{self.kind.value}"
+
+    def __repr__(self) -> str:
+        return f"<{self.kind.name}>"
+
+    def as_dict(self, full: bool = False, **kwargs: Any) -> dict[str, Any]:
+        """Return this object's data as a dictionary.
+
+        Parameters:
+            full: Whether to return full info, or just base info.
+            **kwargs: Additional serialization options.
+
+        Returns:
+            A dictionary.
+        """
+        return {
+            "kind": self.kind,
+            "object_path": self.obj.path,
+            "old_value": self.old_value,
+            "new_value": self.new_value,
+        }
+
+
+class ParameterMovedBreakage(Breakage):
+    """Specific breakage class for moved parameters."""
+
+    kind: BreakageKind = BreakageKind.PARAMETER_MOVED
+
+
+class ParameterRemovedBreakage(Breakage):
+    """Specific breakage class for removed parameters."""
+
+    kind: BreakageKind = BreakageKind.PARAMETER_REMOVED
+
+
+class ParameterChangedKindBreakage(Breakage):
+    """Specific breakage class for parameters whose kind changed."""
+
+    kind: BreakageKind = BreakageKind.PARAMETER_CHANGED_KIND
+
+
+class ParameterChangedDefaultBreakage(Breakage):
+    """Specific breakage class for parameters whose default value changed."""
+
+    kind: BreakageKind = BreakageKind.PARAMETER_CHANGED_DEFAULT
+
+
+class ParameterChangedRequiredBreakage(Breakage):
+    """Specific breakage class for parameters which became required."""
+
+    kind: BreakageKind = BreakageKind.PARAMETER_CHANGED_REQUIRED
+
+
+class ParameterAddedRequiredBreakage(Breakage):
+    """Specific breakage class for new parameters added as required."""
+
+    kind: BreakageKind = BreakageKind.PARAMETER_ADDED_REQUIRED
+
+
+class ReturnChangedTypeBreakage(Breakage):
+    """Specific breakage class for return values which changed type."""
+
+    kind: BreakageKind = BreakageKind.RETURN_CHANGED_TYPE
+
+
+class ObjectRemovedBreakage(Breakage):
+    """Specific breakage class for removed objects."""
+
+    kind: BreakageKind = BreakageKind.OBJECT_REMOVED
+
+
+class ObjectChangedKindBreakage(Breakage):
+    """Specific breakage class for objects whose kind changed."""
+
+    kind: BreakageKind = BreakageKind.OBJECT_CHANGED_KIND
+
+
+class AttributeChangedTypeBreakage(Breakage):
+    """Specific breakage class for attributes whose type changed."""
+
+    kind: BreakageKind = BreakageKind.ATTRIBUTE_CHANGED_TYPE
+
+
+class AttributeChangedValueBreakage(Breakage):
+    """Specific breakage class for attributes whose value changed."""
+
+    kind: BreakageKind = BreakageKind.ATTRIBUTE_CHANGED_VALUE
+
+
+class ClassRemovedBaseBreakage(Breakage):
+    """Specific breakage class for removed base classes."""
+
+    kind: BreakageKind = BreakageKind.CLASS_REMOVED_BASE
+
+
+# TODO: decorators!
+def _class_incompatibilities(old_class: Class, new_class: Class, ignore_private: bool = True) -> Iterable[Breakage]:
+    yield from ()  # noqa WPS353
+    if new_class.bases != old_class.bases:
+        if len(new_class.bases) < len(old_class.bases):
+            yield ClassRemovedBaseBreakage(new_class, old_class.bases, new_class.bases)
+        else:
+            # TODO: check mro
+            ...
+    yield from _member_incompatibilities(old_class, new_class, ignore_private=ignore_private)
+
+
+# TODO: decorators!
+def _function_incompatibilities(old_function: Function, new_function: Function) -> Iterator[Breakage]:  # noqa: WPS231
+    new_param_names = [param.name for param in new_function.parameters]
+    param_kinds = {param.kind for param in new_function.parameters}
+    has_variadic_args = ParameterKind.var_positional in param_kinds
+    has_variadic_kwargs = ParameterKind.var_keyword in param_kinds
+
+    for old_index, old_param in enumerate(old_function.parameters):
+        # checking if parameter was removed
+        if old_param.name not in new_function.parameters:
+            swallowed = (
+                (old_param.kind is ParameterKind.keyword_only and has_variadic_kwargs)  # noqa: WPS222,WPS408
+                or (old_param.kind is ParameterKind.positional_only and has_variadic_args)
+                or (old_param.kind is ParameterKind.positional_or_keyword and has_variadic_args and has_variadic_kwargs)
+            )
+            if not swallowed:
+                yield ParameterRemovedBreakage(new_function, old_param, None)
+            continue
+
+        # checking if parameter became required
+        new_param = new_function.parameters[old_param.name]
+        if new_param.required and not old_param.required:
+            yield ParameterChangedRequiredBreakage(new_function, old_param, new_param)
+
+        # checking if parameter was moved
+        if old_param.kind in POSITIONAL and new_param.kind in POSITIONAL:
+            new_index = new_param_names.index(old_param.name)
+            if new_index != old_index:
+                details = f"position: from {old_index} to {new_index} ({new_index - old_index:+})"
+                yield ParameterMovedBreakage(new_function, old_param, new_param, details=details)
+
+        # checking if parameter changed kind
+        if old_param.kind is not new_param.kind:
+            incompatible_kind = any(
+                (
+                    # positional-only to keyword-only
+                    old_param.kind is ParameterKind.positional_only and new_param.kind is ParameterKind.keyword_only,
+                    # keyword-only to positional-only
+                    old_param.kind is ParameterKind.keyword_only and new_param.kind is ParameterKind.positional_only,
+                    # positional or keyword to positional-only/keyword-only
+                    old_param.kind is ParameterKind.positional_or_keyword and new_param.kind in POSITIONAL_KEYWORD_ONLY,
+                    # not keyword-only to variadic keyword, without variadic positional
+                    new_param.kind is ParameterKind.var_keyword
+                    and old_param.kind is not ParameterKind.keyword_only
+                    and not has_variadic_args,
+                    # not positional-only to variadic positional, without variadic keyword
+                    new_param.kind is ParameterKind.var_positional
+                    and old_param.kind is not ParameterKind.positional_only
+                    and not has_variadic_kwargs,
+                )
+            )
+            if incompatible_kind:
+                yield ParameterChangedKindBreakage(new_function, old_param, new_param)
+
+        # checking if parameter changed default
+        breakage = ParameterChangedDefaultBreakage(new_function, old_param, new_param)
+        try:
+            if old_param.default is not None and old_param.default != new_param.default:
+                yield breakage
+        except Exception:  # equality checks sometimes fail, e.g. numpy arrays
+            # TODO: emitting breakage on a failed comparison could be a preference
+            yield breakage
+
+    # checking if required parameters were added
+    for new_param in new_function.parameters:  # noqa: WPS440
+        if new_param.name not in old_function.parameters and new_param.required:
+            yield ParameterAddedRequiredBreakage(new_function, None, new_param)
+
+    if not _returns_are_compatible(old_function, new_function):
+        yield ReturnChangedTypeBreakage(new_function, old_function.returns, new_function.returns)
+
+
+def _attribute_incompatibilities(old_attribute: Attribute, new_attribute: Attribute) -> Iterable[Breakage]:
+    # TODO: use beartype.peps.resolve_pep563 and beartype.door.is_subhint?
+    # if old_attribute.annotation is not None and new_attribute.annotation is not None:
+    #     if not is_subhint(new_attribute.annotation, old_attribute.annotation):
+    #         yield AttributeChangedTypeBreakage(new_attribute, old_attribute.annotation, new_attribute.annotation)
+    if old_attribute.value != new_attribute.value:
+        yield AttributeChangedValueBreakage(new_attribute, old_attribute.value, new_attribute.value)
+
+
+def _member_incompatibilities(  # noqa: WPS231
+    old_obj: Object | Alias,
+    new_obj: Object | Alias,
+    ignore_private: bool = True,
+) -> Iterator[Breakage]:
+    for name, old_member in old_obj.members.items():
+        if ignore_private and name.startswith("_"):
+            continue
+
+        if old_member.is_alias:
+            continue  # TODO
+
+        try:
+            new_member = new_obj.members[name]
+        except KeyError:
+            if old_member.is_exported(explicitely=False):
+                yield ObjectRemovedBreakage(old_member, old_member, None)  # type: ignore[arg-type]
+            continue
+
+        if new_member.kind != old_member.kind:
+            yield ObjectChangedKindBreakage(new_member, old_member.kind, new_member.kind)  # type: ignore[arg-type]
+        elif old_member.is_module:
+            yield from _member_incompatibilities(old_member, new_member, ignore_private=ignore_private)  # type: ignore[arg-type]
+        elif old_member.is_class:
+            yield from _class_incompatibilities(old_member, new_member, ignore_private=ignore_private)  # type: ignore[arg-type]
+        elif old_member.is_function:
+            yield from _function_incompatibilities(old_member, new_member)  # type: ignore[arg-type]
+        elif old_member.is_attribute:
+            yield from _attribute_incompatibilities(old_member, new_member)  # type: ignore[arg-type]
+
+
+def _returns_are_compatible(old_function: Function, new_function: Function) -> bool:
+    if old_function.returns is None:
+        return True
+    if new_function.returns is None:
+        # TODO: it should be configurable to allow/disallow removing a return type
+        return False
+
+    with contextlib.suppress(AttributeError):
+        if new_function.returns == old_function.returns:
+            return True
+
+    # TODO: use beartype.peps.resolve_pep563 and beartype.door.is_subhint?
+    return True
+
+
+find_breaking_changes = _member_incompatibilities

--- a/src/griffe/expressions.py
+++ b/src/griffe/expressions.py
@@ -29,8 +29,8 @@ class Name:
             self._full = ""
             self._resolver = full
 
-    def __eq__(self, other: Name) -> bool:  # type: ignore[override]
-        return self.source == other.source and self.full == other.full  # noqa: WPS437
+    def __eq__(self, other: Name | Expression) -> bool:  # type: ignore[override]
+        return self.full == other.full  # noqa: WPS437
 
     def __repr__(self) -> str:
         return f"Name(source={self.source!r}, full={self.full!r})"

--- a/src/griffe/git.py
+++ b/src/griffe/git.py
@@ -74,6 +74,7 @@ def tmp_worktree(commit: str = "HEAD", repo: str | Path = ".") -> Iterator[Path]
 
 def load_git(
     module: str | Path,
+    *,
     commit: str = "HEAD",
     repo: str | Path = ".",
     submodules: bool = True,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4,7 +4,7 @@ import sys
 
 import pytest
 
-from griffe import cli
+from griffe import cli  # type: ignore[attr-defined]
 
 
 def test_main():

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -1,0 +1,184 @@
+"""Tests for the `diff` module."""
+
+import sys
+
+import pytest
+
+from griffe.diff import BreakageKind, find_breaking_changes
+from tests.helpers import temporary_visited_module
+
+
+@pytest.mark.skipif(sys.version_info < (3, 8), reason="no positional-only parameters on Python 3.7")
+@pytest.mark.parametrize(
+    ("old_code", "new_code", "expected_breakages"),
+    [
+        # (
+        #     "var: int",
+        #     "var: str",
+        #     [BreakageKind.ATTRIBUTE_CHANGED_TYPE],
+        # ),
+        (
+            "a = True",
+            "a = False",
+            [BreakageKind.ATTRIBUTE_CHANGED_VALUE],
+        ),
+        (
+            "class A(int, str): ...",
+            "class A(int): ...",
+            [BreakageKind.CLASS_REMOVED_BASE],
+        ),
+        (
+            "A = 0",
+            "class A: ...",
+            [BreakageKind.OBJECT_CHANGED_KIND],
+        ),
+        (
+            "a = True",
+            "",
+            [BreakageKind.OBJECT_REMOVED],
+        ),
+        (
+            "def a(): ...",
+            "def a(x): ...",
+            [BreakageKind.PARAMETER_ADDED_REQUIRED],
+        ),
+        (
+            "def a(x=0): ...",
+            "def a(x=1): ...",
+            [BreakageKind.PARAMETER_CHANGED_DEFAULT],
+        ),
+        (
+            # positional-only to keyword-only
+            "def a(x, /): ...",
+            "def a(*, x): ...",
+            [BreakageKind.PARAMETER_CHANGED_KIND],
+        ),
+        (
+            # keyword-only to positional-only
+            "def a(*, x): ...",
+            "def a(x, /): ...",
+            [BreakageKind.PARAMETER_CHANGED_KIND],
+        ),
+        (
+            # positional or keyword to positional-only
+            "def a(x): ...",
+            "def a(x, /): ...",
+            [BreakageKind.PARAMETER_CHANGED_KIND],
+        ),
+        (
+            # positional or keyword to keyword-only
+            "def a(x): ...",
+            "def a(*, x): ...",
+            [BreakageKind.PARAMETER_CHANGED_KIND],
+        ),
+        # to variadic positional
+        (
+            # positional-only to variadic positional
+            "def a(x, /): ...",
+            "def a(*x): ...",
+            [],
+        ),
+        (
+            # positional or keyword to variadic positional
+            "def a(x): ...",
+            "def a(*x): ...",
+            [BreakageKind.PARAMETER_CHANGED_KIND],
+        ),
+        (
+            # keyword-only to variadic positional
+            "def a(*, x): ...",
+            "def a(*x): ...",
+            [BreakageKind.PARAMETER_CHANGED_KIND],
+        ),
+        (
+            # variadic keyword to variadic positional
+            "def a(**x): ...",
+            "def a(*x): ...",
+            [BreakageKind.PARAMETER_CHANGED_KIND],
+        ),
+        (
+            # positional or keyword to variadic positional, with variadic keyword
+            "def a(x): ...",
+            "def a(*x, **y): ...",
+            [],
+        ),
+        (
+            # keyword-only to variadic positional, with variadic keyword
+            "def a(*, x): ...",
+            "def a(*x, **y): ...",
+            [],
+        ),
+        # to variadic keyword
+        (
+            # positional-only to variadic keyword
+            "def a(x, /): ...",
+            "def a(**x): ...",
+            [BreakageKind.PARAMETER_CHANGED_KIND],
+        ),
+        (
+            # positional or keyword to variadic keyword
+            "def a(x): ...",
+            "def a(**x): ...",
+            [BreakageKind.PARAMETER_CHANGED_KIND],
+        ),
+        (
+            # keyword-only to variadic keyword
+            "def a(*, x): ...",
+            "def a(**x): ...",
+            [],
+        ),
+        (
+            # variadic positional to variadic keyword
+            "def a(*x): ...",
+            "def a(**x): ...",
+            [BreakageKind.PARAMETER_CHANGED_KIND],
+        ),
+        (
+            # positional-only to variadic keyword, with variadic positional
+            "def a(x, /): ...",
+            "def a(*y, **x): ...",
+            [],
+        ),
+        (
+            # positional or keyword to variadic keyword, with variadic positional
+            "def a(x): ...",
+            "def a(*y, **x): ...",
+            [],
+        ),
+        (
+            "def a(x=1): ...",
+            "def a(x): ...",
+            [BreakageKind.PARAMETER_CHANGED_REQUIRED],
+        ),
+        (
+            "def a(x, y): ...",
+            "def a(y, x): ...",
+            [BreakageKind.PARAMETER_MOVED],
+        ),
+        (
+            "def a(x, y): ...",
+            "def a(x): ...",
+            [BreakageKind.PARAMETER_REMOVED],
+        ),
+        (
+            "def a() -> int: ...",
+            "def a() -> str: ...",
+            [BreakageKind.RETURN_CHANGED_TYPE],
+        ),
+    ],
+)
+def test_diff_griffe(old_code, new_code, expected_breakages):
+    """Test the different incompatibility finders.
+
+    Parameters:
+        old_code: Parametrized code of the old module version.
+        new_code: Parametrized code of the new module version.
+        expected_breakages: A list of breakage kinds to expect.
+    """
+    with temporary_visited_module(old_code) as old_module:
+        with temporary_visited_module(new_code) as new_module:
+            breaking = list(find_breaking_changes(old_module, new_module))
+    if not expected_breakages:
+        assert not breaking
+    for breakage, expected_kind in zip(breaking, expected_breakages):
+        assert breakage.kind is expected_kind

--- a/tests/test_encoders.py
+++ b/tests/test_encoders.py
@@ -1,4 +1,5 @@
 """Tests for the `encoders` module."""
+
 import pytest
 
 from griffe.dataclasses import Function, Module, Object

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -112,13 +112,13 @@ def test_visit_function_variadic_params():
         function = module["f"]
         assert len(function.parameters) == 3
         param = function.parameters[0]
-        assert param.name == "*args"
+        assert param.name == "args"
         assert param.annotation.source == "str"
         assert param.annotation.full == "str"
         param = function.parameters[1]
         assert param.annotation is None
         param = function.parameters[2]
-        assert param.name == "**kwargs"
+        assert param.name == "kwargs"
         assert param.annotation.source == "int"
         assert param.annotation.full == "int"
 

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -1,4 +1,5 @@
 """Tests for creating a griffe Module from specific commits in a git repository."""
+
 import shutil
 from pathlib import Path
 from subprocess import run  # noqa: S404


### PR DESCRIPTION
Co-authored-by: Talley Lambert <talley.lambert@gmail.com>

---

@tlambert03, following discussion in #75, I've taken your code in griffediff, updated it to my taste (I hope you don't mind :sweat:) and credited you of course. This PR is still a draft anyway, just experimenting a bit.

What I envision is:

- utility to yield more than breakages: yield everything that changed or was added/removed (for auto-documentation purposes) and attach these data to objects
- also attach detected breakages to objects
- utility to yield forward-compatibility hints: "set these parameters as keyword-only" here and there, etc., and attach these data to objects. These hints could be displayed in docs auto-generated through mkdocstrings when serving only, to inform the developer :thinking:
- of course: add CLI options to show hints and breakages