### PR TITLE
fix: Don't strip too many parentheses on the right of a call node

### DIFF
--- a/src/griffe/agents/nodes.py
+++ b/src/griffe/agents/nodes.py
@@ -1094,8 +1094,8 @@ def _get_sub_value(node: NodeSub) -> str:
 
 def _get_subscript_value(node: NodeSubscript) -> str:
     subscript = _get_value(node.slice)
-    if isinstance(subscript, str):
-        subscript = subscript.strip("()")
+    if isinstance(subscript, str) and subscript.startswith("(") and subscript.endswith(")"):
+        subscript = subscript[1:-1]
     return f"{_get_value(node.value)}[{subscript}]"
 
 

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -190,6 +190,7 @@ def test_default_value_from_nodes(default):
         "o[x,y]",
         "o[x:y]",
         "o[x:y,z]",
+        "o[x, y(z)]",
     ],
 )
 def test_building_value_from_nodes(expression):


### PR DESCRIPTION
Previously a value like `o[x, y(z)]` would be unparsed as `o[x, y(z]` (missing right parenthesis). Reported on Gitter.