### PR TITLE
feat: support typing_extensions.overload

### DIFF
--- a/src/griffe/agents/visitor.py
+++ b/src/griffe/agents/visitor.py
@@ -319,9 +319,9 @@ class Visitor(BaseVisitor):  # noqa: WPS338
             for decorator_node in node.decorator_list:
                 decorator_value = safe_get_value(decorator_node, self.filepath)
                 overload = (
-                    decorator_value == "typing.overload"
+                    decorator_value in ("typing.overload", "typing_extensions.overload")
                     or decorator_value == "overload"
-                    and self.current.resolve("overload") == "typing.overload"
+                    and self.current.resolve("overload") in ("typing.overload", "typing_extensions.overload")
                 )
                 decorators.append(
                     Decorator(

--- a/src/griffe/agents/visitor.py
+++ b/src/griffe/agents/visitor.py
@@ -60,6 +60,7 @@ stdlib_decorators = {
     "functools.lru_cache": {"cached"},
     "dataclasses.dataclass": {"dataclass"},
 }
+typing_overload = {"typing.overload", "typing_extensions.overload"}
 
 
 def visit(
@@ -319,9 +320,9 @@ class Visitor(BaseVisitor):  # noqa: WPS338
             for decorator_node in node.decorator_list:
                 decorator_value = safe_get_value(decorator_node, self.filepath)
                 overload = (
-                    decorator_value in ("typing.overload", "typing_extensions.overload")
+                    decorator_value in typing_overload
                     or decorator_value == "overload"
-                    and self.current.resolve("overload") in ("typing.overload", "typing_extensions.overload")
+                    and self.current.resolve("overload") in typing_overload
                 )
                 decorators.append(
                     Decorator(


### PR DESCRIPTION
Support `overload` from `typing_extensions` as it was introduced in [4.2.0](https://github.com/python/typing_extensions/blob/main/CHANGELOG.md#release-420-april-17-2022), allowing runtime inspection of overloads.