### PR TITLE
fix: Log debug instead of errors when failing to parse NumPy annotations for additional sections

### DIFF
--- a/src/griffe/docstrings/numpy.py
+++ b/src/griffe/docstrings/numpy.py
@@ -376,7 +376,7 @@ def _read_returns_section(  # noqa: WPS231
                         else:
                             annotation = return_item
         else:
-            annotation = parse_annotation(annotation, docstring)  # type: ignore[arg-type]
+            annotation = parse_annotation(annotation, docstring, log_level=LogLevel.debug)  # type: ignore[arg-type]
         returns.append(DocstringReturn(name=name or "", annotation=annotation, description=text))
     return DocstringSectionReturns(returns), new_offset
 
@@ -423,7 +423,7 @@ def _read_yields_section(  # noqa: WPS231
                     else:
                         annotation = yield_item
         else:
-            annotation = parse_annotation(annotation, docstring)  # type: ignore[arg-type]
+            annotation = parse_annotation(annotation, docstring, log_level=LogLevel.debug)  # type: ignore[arg-type]
         yields.append(DocstringYield(name=name or "", annotation=annotation, description=text))
     return DocstringSectionYields(yields), new_offset
 
@@ -465,7 +465,7 @@ def _read_receives_section(  # noqa: WPS231
                     else:
                         annotation = receives_item
         else:
-            annotation = parse_annotation(annotation, docstring)  # type: ignore[arg-type]
+            annotation = parse_annotation(annotation, docstring, log_level=LogLevel.debug)  # type: ignore[arg-type]
         receives.append(DocstringReceive(name=name or "", annotation=annotation, description=text))
     return DocstringSectionReceives(receives), new_offset
 
@@ -543,7 +543,7 @@ def _read_attributes_section(
             with suppress(AttributeError, KeyError):
                 annotation = docstring.parent.members[name].annotation  # type: ignore[union-attr]
         else:
-            annotation = parse_annotation(annotation, docstring)  # type: ignore[arg-type]
+            annotation = parse_annotation(annotation, docstring, log_level=LogLevel.debug)  # type: ignore[arg-type]
         text = dedent("\n".join(item[1:]))
         attributes.append(DocstringAttribute(name=name, annotation=annotation, description=text))
     return DocstringSectionAttributes(attributes), new_offset

--- a/tests/test_docstrings/test_numpy.py
+++ b/tests/test_docstrings/test_numpy.py
@@ -182,9 +182,29 @@ def test_dont_crash_on_text_annotations(parse_numpy, caplog):
         caplog: Pytest fixture used to capture logs.
     """
     docstring = """
+        Attributes
+        ----------
+        region : str, list-like, geopandas.GeoSeries, geopandas.GeoDataFrame, geometric
+            Description.
+
         Parameters
         ----------
         region : str, list-like, geopandas.GeoSeries, geopandas.GeoDataFrame, geometric
+            Description.
+
+        Returns
+        -------
+        str or bytes
+            Description.
+
+        Receives
+        --------
+        region : str, list-like, geopandas.GeoSeries, geopandas.GeoDataFrame, geometric
+            Description.
+
+        Yields
+        ------
+        str or bytes
             Description.
     """
     caplog.set_level(logging.DEBUG)


### PR DESCRIPTION
I've fixed support for NumPy annotations, that aren't conformant with PEP 484, for additional docstring sections:

* Attributes
* Returns
* Receives
* Yields

Follow-up of 75eeeda2f1181ae680b3d47df3814bad200220d3. Fixes https://github.com/mkdocstrings/griffe/issues/93#issuecomment-1291784022.