### PR TITLE
fix: catch recursion in Alias.resolved

### DIFF
--- a/src/griffe/dataclasses.py
+++ b/src/griffe/dataclasses.py
@@ -973,13 +973,9 @@ class Alias(ObjectAliasMixin):
         Returns:
             True or False.
         """
-        try:
-            return self._target is not None and (not self._target.is_alias or self._target.resolved)  # type: ignore[union-attr]
-        except RecursionError as e:
-            import warnings
-
-            warnings.warn(f"Cyclic aliases detected : {self.target_path}")
+        if getattr(self._target, "_target", None) is self:  # circular alias
             return False
+        return self._target is not None and (not self._target.is_alias or self._target.resolved)  # type: ignore[union-attr]
 
     @cached_property
     def wildcard(self) -> str | None:

--- a/src/griffe/dataclasses.py
+++ b/src/griffe/dataclasses.py
@@ -973,7 +973,13 @@ class Alias(ObjectAliasMixin):
         Returns:
             True or False.
         """
-        return self._target is not None and (not self._target.is_alias or self._target.resolved)  # type: ignore[union-attr]
+        try:
+            return self._target is not None and (not self._target.is_alias or self._target.resolved)  # type: ignore[union-attr]
+        except RecursionError as e:
+            import warnings
+
+            warnings.warn(f"Cyclic aliases detected : {self.target_path}")
+            return False
 
     @cached_property
     def wildcard(self) -> str | None:


### PR DESCRIPTION
hey @pawamoy 

I'm sure this is probably your least favorite bug at this point :joy: ... but I ran into an Alias resolution recursion error, similar to https://github.com/mkdocstrings/griffe/issues/83

<details>

<summary>Full traceback:</summary>

```pytb
Traceback (most recent call last):
  File "/Users/talley/mambaforge/envs/mmcore/bin/mkdocs", line 8, in <module>
    sys.exit(cli())
  File "/Users/talley/mambaforge/envs/mmcore/lib/python3.10/site-packages/click/core.py", line 1130, in __call__
    return self.main(*args, **kwargs)
  File "/Users/talley/mambaforge/envs/mmcore/lib/python3.10/site-packages/click/core.py", line 1055, in main
    rv = self.invoke(ctx)
  File "/Users/talley/mambaforge/envs/mmcore/lib/python3.10/site-packages/click/core.py", line 1657, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/talley/mambaforge/envs/mmcore/lib/python3.10/site-packages/click/core.py", line 1404, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/talley/mambaforge/envs/mmcore/lib/python3.10/site-packages/click/core.py", line 760, in invoke
    return __callback(*args, **kwargs)
  File "/Users/talley/mambaforge/envs/mmcore/lib/python3.10/site-packages/mkdocs/__main__.py", line 234, in serve_command
    serve.serve(dev_addr=dev_addr, livereload=livereload, watch=watch, **kwargs)
  File "/Users/talley/mambaforge/envs/mmcore/lib/python3.10/site-packages/mkdocs/commands/serve.py", line 83, in serve
    builder(config)
  File "/Users/talley/mambaforge/envs/mmcore/lib/python3.10/site-packages/mkdocs/commands/serve.py", line 76, in builder
    build(config, live_server=live_server, dirty=dirty)
  File "/Users/talley/mambaforge/envs/mmcore/lib/python3.10/site-packages/mkdocs/commands/build.py", line 308, in build
    _populate_page(file.page, config, files, dirty)
  File "/Users/talley/mambaforge/envs/mmcore/lib/python3.10/site-packages/mkdocs/commands/build.py", line 181, in _populate_page
    page.render(config, files)
  File "/Users/talley/mambaforge/envs/mmcore/lib/python3.10/site-packages/mkdocs/structure/pages.py", line 270, in render
    self.content = md.convert(self.markdown)
  File "/Users/talley/mambaforge/envs/mmcore/lib/python3.10/site-packages/markdown/core.py", line 264, in convert
    root = self.parser.parseDocument(self.lines).getroot()
  File "/Users/talley/mambaforge/envs/mmcore/lib/python3.10/site-packages/markdown/blockparser.py", line 90, in parseDocument
    self.parseChunk(self.root, '\n'.join(lines))
  File "/Users/talley/mambaforge/envs/mmcore/lib/python3.10/site-packages/markdown/blockparser.py", line 105, in parseChunk
    self.parseBlocks(parent, text.split('\n\n'))
  File "/Users/talley/mambaforge/envs/mmcore/lib/python3.10/site-packages/markdown/blockparser.py", line 123, in parseBlocks
    if processor.run(parent, blocks) is not False:
  File "/Users/talley/mambaforge/envs/mmcore/lib/python3.10/site-packages/mkdocstrings/extension.py", line 121, in run
    html, handler, data = self._process_block(identifier, block, heading_level)
  File "/Users/talley/mambaforge/envs/mmcore/lib/python3.10/site-packages/mkdocstrings/extension.py", line 195, in _process_block
    data: CollectorItem = handler.collect(identifier, options)
  File "/Users/talley/mambaforge/envs/mmcore/lib/python3.10/site-packages/mkdocstrings_handlers/python/handler.py", line 199, in collect
    unresolved, iterations = loader.resolve_aliases(implicit=False, external=False)
  File "/Users/talley/dev/forks/griffe/src/griffe/loader.py", line 217, in resolve_aliases
    next_resolved, next_unresolved = self.resolve_module_aliases(module, implicit, external)
  File "/Users/talley/dev/forks/griffe/src/griffe/loader.py", line 357, in resolve_module_aliases
    sub_resolved, sub_unresolved = self.resolve_module_aliases(
  File "/Users/talley/dev/forks/griffe/src/griffe/loader.py", line 338, in resolve_module_aliases
    member.resolve_target()  # type: ignore[union-attr]
  File "/Users/talley/dev/forks/griffe/src/griffe/dataclasses.py", line 967, in resolve_target
    self._target.aliases[self.path] = self  # type: ignore[union-attr]  # we just set the target
  File "/Users/talley/dev/forks/griffe/src/griffe/dataclasses.py", line 827, in __getattr__
    attr = getattr(self.target, name)
  File "/Users/talley/dev/forks/griffe/src/griffe/dataclasses.py", line 935, in target
    if not self.resolved:
  File "/Users/talley/dev/forks/griffe/src/griffe/dataclasses.py", line 976, in resolved
    return self._target is not None and (not self._target.is_alias or self._target.resolved)  # type: ignore[union-attr]
  File "/Users/talley/dev/forks/griffe/src/griffe/dataclasses.py", line 976, in resolved
    return self._target is not None and (not self._target.is_alias or self._target.resolved)  # type: ignore[union-attr]
  File "/Users/talley/dev/forks/griffe/src/griffe/dataclasses.py", line 976, in resolved
    return self._target is not None and (not self._target.is_alias or self._target.resolved)  # type: ignore[union-attr]
  [Previous line repeated 971 more times]
RecursionError: maximum recursion depth exceeded
```

</details>


In this case, it does appear to be a legitimate Cyclic Alias... that is `self._target._target is self`.

For what it's worth, the class I was trying to document with mkdocstrings is from pymmcore (`pip install pymmcore`)
 
```md
::: pymmcore.CMMCore
```

... and that class is a SWIG wrapper with a [`.pyi` type stub](https://github.com/micro-manager/pymmcore/blob/main/pymmcore/__init__.pyi#L197) providing the signatures and docstring.  And the cyclic aliases look like:

```
<Alias('CMMCore', 'pymmcore.pymmcore_swig.CMMCore')>
<Alias('CMMCore', 'pymmcore._pymmcore_swig.CMMCore')>
<Alias('CMMCore', 'pymmcore.pymmcore_swig.CMMCore')>
<Alias('CMMCore', 'pymmcore._pymmcore_swig.CMMCore')>
...
```


I opened this as a PR rather than an issue, since this _does_ fix the docs building (the page looks exactly how I'd expect it to)... but I'm not sure what the actual best fix is.  Feel free to close or suggest a better approach here for me to implement