### PR TITLE
fix: support editable install with multiple roots

### DIFF
--- a/src/griffe/finder.py
+++ b/src/griffe/finder.py
@@ -339,7 +339,6 @@ def _handle_editable_module(path: Path):  # noqa: WPS231
         editable_lines = path.read_text(encoding="utf8").splitlines(keepends=False)
     except FileNotFoundError:
         raise UnhandledEditableModuleError(path)
-
     if path.name.startswith("__editables_"):
         # support for how 'editables' writes these files:
         # example line: F.map_module('griffe', '/media/data/dev/griffe/src/griffe/__init__.py')

--- a/tests/test_finder.py
+++ b/tests/test_finder.py
@@ -94,7 +94,7 @@ def test_editables_file_handling(tmp_path):
     """
     pth_file = tmp_path / "__editables_whatever.py"
     pth_file.write_text("hello\nF.map_module('griffe', 'src/griffe/__init__.py')")
-    assert _handle_editable_module(pth_file) == Path("src")
+    assert _handle_editable_module(pth_file) == [Path("src")]
 
 
 def test_setuptools_file_handling(tmp_path):
@@ -105,4 +105,17 @@ def test_setuptools_file_handling(tmp_path):
     """
     pth_file = tmp_path / "__editable__whatever.py"
     pth_file.write_text("hello\nMAPPING = {'griffe': 'src/griffe'}")
-    assert _handle_editable_module(pth_file) == Path("src")
+    assert _handle_editable_module(pth_file) == [Path("src")]
+
+
+def test_setuptools_file_handling_multiple_paths(tmp_path):
+    """Assert editable modules by `setuptools` are handled when multiple packages are installed in the same editable.
+
+    Parameters:
+        tmp_path: Pytest fixture.
+    """
+    pth_file = tmp_path / "__editable__whatever.py"
+    pth_file.write_text(
+        "hello=1\nMAPPING = {\n'griffe':\n 'src1/griffe', 'briffe':'src2/briffe'}\ndef printer():\n  print(hello)"
+    )
+    assert _handle_editable_module(pth_file) == [Path("src1"), Path("src2")]


### PR DESCRIPTION
Python packages may have multiple root modules where each is installed to its own folder under `site-packages`.

When using new setuptools editable install in such cases griffe, when used by mkdocstrings fails to find the correct paths.

The root cause it that griffe assumed a variable named `MAPPING` in the `.py` file created by the editable install, and assumed that this variable is a dict with single entry.

When a package has multiple roots - then this dictionary contain multiple entries.

This PR aims to handle such cases.

I have no knowledge about `editables` so I could not fix that case.

The unit test added simulates the case, and this has been tested against a real complex package with multiple roots using setuptools 65 editable install.