### PR TITLE
docs: minor typo fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ See [the Loading data section](https://mkdocstrings.github.io/griffe/loading/) f
     - Flat JSON
     - JSON schema
 - API diff:
-    - [ ] Mecanism to cache APIs? Should users version them, or store them somewhere (docs)?
+    - [ ] Mechanism to cache APIs? Should users version them, or store them somewhere (docs)?
     - [ ] Ability to return warnings (things that are not backward-compatibility-friendly)
     - List of things to consider for warnings
         - Multiple positional-or-keyword parameters

--- a/README.md
+++ b/README.md
@@ -36,12 +36,16 @@ pipx install griffe
 
 ```console
 $ griffe dump httpx fastapi
-[
-  {
+{
+  "httpx": {
     "name": "httpx",
     ...
+  },
+  "fastapi": {
+    "name": "fastapi",
+    ...
   }
-]
+}
 ```
 
 See [the Dumping data section](https://mkdocstrings.github.io/griffe/dumping/) for more examples.

--- a/docs/checking.md
+++ b/docs/checking.md
@@ -68,7 +68,7 @@ In essence, your public API is what you say it is.
 However, we do have conventions like prefixing objects
 with an underscore to tell users these objects are part of the private API,
 or internals, and therefore should not be used.
-For the rest, Griffe can detect changes that *will* trigger immedate errors
+For the rest, Griffe can detect changes that *will* trigger immediate errors
 in your users code', and changes that *might* cause issues in your users' code.
 Although the latter sound less impactful, they do have a serious impact,
 because they can *silently* change the behavior of your users' code,
@@ -107,7 +107,7 @@ depending on our definition of API,
 since this won't raise immediate errors like `TypeError`.
 The function expects a number of arguments,
 and the developer pass it this same number of arguments:
-the contract is fullfilled. But parameters very often have specific meaning,
+the contract is fulfilled. But parameters very often have specific meaning,
 and changing their order will *silently lead* (no immediate error) to incorrect behavior,
 potentially making it difficult to detect, understand and fix the issue.
 That is why it is important to warn developers about such changes.
@@ -360,7 +360,7 @@ NOTE: Changing default value of parameters is not really an API breakage,
 depending on our definition of API,
 since this won't raise immediate errors like `TypeError`.
 Not using the parameter still provides the argument with a default value:
-the contract is fullfilled. But default values very often have specific meaning,
+the contract is fulfilled. But default values very often have specific meaning,
 and changing them will *silently lead* (no immediate error) to incorrect behavior,
 potentially making it difficult to detect, understand and fix the issue.
 That is why it is important to warn developers about such changes.
@@ -562,7 +562,7 @@ if isinstance(factory, Factory):
 NOTE: Changing the kind of an object is not really an API breakage,
 depending on our definition of API,
 since this won't always raise immediate errors like `TypeError`.
-The object is still here and accessed: the contract is fullfilled.
+The object is still here and accessed: the contract is fulfilled.
 But developers sometimes rely on the kind of an object, so changing it
 will lead to incorrect behavior, potentially making it
 difficult to detect, understand and fix the issue.
@@ -603,7 +603,7 @@ if PY_VERSION is None:
 NOTE: Changing the value of an attribute is not really an API breakage,
 depending on our definition of API,
 since this won't raise immediate errors like `TypeError`.
-The attribute is still here and accessed: the contract is fullfilled.
+The attribute is still here and accessed: the contract is fulfilled.
 But developers heavily rely on the value of public attributes,
 so changing it will lead to incorrect behavior, potentially making it
 difficult to detect, understand and fix the issue.
@@ -646,7 +646,7 @@ NOTE: Unless inherited members are lost in the process,
 removing a class base is not really an API breakage,
 depending on our definition of API,
 since this won't raise immediate errors like `TypeError`.
-The class is here, its members as well: the contract is fullfilled.
+The class is here, its members as well: the contract is fulfilled.
 But developers sometimes rely on the actual bases of a class,
 so changing them will lead to incorrect behavior, potentially making it
 difficult to detect, understand and fix the issue.

--- a/docs/dumping.md
+++ b/docs/dumping.md
@@ -8,12 +8,16 @@ Pass the names of packages to the `griffe dump` command:
 
 ```console
 $ griffe dump httpx fastapi
-[
-  {
+{
+  "httpx": {
     "name": "httpx",
     ...
+  },
+  "fastapi": {
+    "name": "fastapi",
+    ...
   }
-]
+}
 ```
 
 It will output a JSON-serialized version of the packages' signatures.
@@ -22,12 +26,12 @@ Try it out on Griffe itself:
 
 ```console
 $ griffe dump griffe
-[
-  {
+{
+  "griffe": {
     "name": "griffe",
     ...
   }
-]
+}
 ```
 
 To output in a file instead of standard output,

--- a/docs/dumping.md
+++ b/docs/dumping.md
@@ -46,7 +46,7 @@ $ griffe dump griffe -o './dumps/{package}.json'
 
 By default, Griffe will search in `sys.path`, so if you installed it through *pipx*,
 there are few chances it will find your packages.
-To explicitely specify search paths, use the `-s, --search <PATH>` option.
+To explicitly specify search paths, use the `-s, --search <PATH>` option.
 You can use it multiple times.
 You can also add the search paths to the `PYTHONPATH` environment variable.
 If Griffe can't find the packages, it will fail with a `ModuleNotFoundError`.

--- a/docs/loading.md
+++ b/docs/loading.md
@@ -1,6 +1,6 @@
 # Loading data with Python
 
-Griffe provides a shorcut function for simple needs:
+Griffe provides a shortcut function for simple needs:
 
 ```python
 import griffe

--- a/src/griffe/docstrings/google.py
+++ b/src/griffe/docstrings/google.py
@@ -173,7 +173,7 @@ def _read_parameters(  # noqa: WPS231
 
     for line_number, param_lines in block:
 
-        # check the presence of a name and description, separated by a semi-colon
+        # check the presence of a name and description, separated by a colon
         try:
             name_with_type, description = param_lines[0].split(":", 1)
         except ValueError:


### PR DESCRIPTION
Just a couple of typo fixes to the docs.

And I realized the output of `griffe dump` is an object, not an array anymore, so updated the docs to reflect that