### PR TITLE
fix: Allow Raises and Warns sections to start with a newline

### DIFF
--- a/src/griffe/docstrings/google.py
+++ b/src/griffe/docstrings/google.py
@@ -310,7 +310,7 @@ def _read_raises_section(
     annotation: str | Name | Expression
     for line_number, exception_lines in block:
         try:
-            annotation, description = exception_lines[0].split(": ", 1)
+            annotation, description = exception_lines[0].split(":", 1)
         except ValueError:
             _warn(docstring, line_number, f"Failed to get 'exception: description' pair from '{exception_lines[0]}'")
         else:
@@ -337,7 +337,7 @@ def _read_warns_section(
 
     for line_number, warning_lines in block:
         try:
-            annotation, description = warning_lines[0].split(": ", 1)
+            annotation, description = warning_lines[0].split(":", 1)
         except ValueError:
             _warn(docstring, line_number, f"Failed to get 'warning: description' pair from '{warning_lines[0]}'")
         else:

--- a/tests/test_docstrings/test_google.py
+++ b/tests/test_docstrings/test_google.py
@@ -178,6 +178,32 @@ def test_empty_indented_lines_in_section_with_items(parse_google: ParserType) ->
     assert len(sections[0].value) == 1
 
 
+@pytest.mark.parametrize(
+    "section",
+    [
+        "Attributes",
+        "Other Parameters",
+        "Parameters",
+        "Raises",
+        "Receives",
+        "Returns",
+        "Yields",
+    ],
+)
+def test_starting_item_description_on_new_line(parse_google: ParserType, section: str) -> None:
+    """In sections with items, allow starting item descriptions on a new (indented) line.
+
+    Parameters:
+        parse_google: Fixture parser.
+        section: A parametrized section name.
+    """
+    docstring = f"\n{section}:\n    only_item:\n        Description."
+    sections, _ = parse_google(docstring)
+    assert len(sections) == 1
+    assert len(sections[0].value) == 1
+    assert sections[0].value[0].description.strip() == "Description."
+
+
 # =============================================================================================
 def test_parse_without_parent(parse_google: ParserType) -> None:
     """Parse a docstring without a parent function.


### PR DESCRIPTION
According to the documentation it's possible to start a description with a newline.
However, this did not work properly for Raises and Warns sections, because of a stray space in the regex to split the annotation and its description.
