### PR TITLE
Respect ClassVar variable annotation

### DIFF
--- a/src/griffe/agents/visitor.py
+++ b/src/griffe/agents/visitor.py
@@ -560,11 +560,15 @@ class Visitor(BaseVisitor):
                 return
 
             if isinstance(annotation, Expression) and annotation.is_classvar:
+                # explicit classvar: class attribute only
                 annotation = annotation[2]
                 labels.add("class-attribute")
             elif node.value:
+                # attribute assigned at class-level: available in instances as well
                 labels.add("class-attribute")
+                labels.add("instance-attribute")
             else:
+                # annotated attribute only: not available at class-level
                 labels.add("instance-attribute")
 
         elif parent.kind is Kind.FUNCTION:

--- a/src/griffe/expressions.py
+++ b/src/griffe/expressions.py
@@ -162,6 +162,15 @@ class Expression(list):
         """
         return self.kind == "generator"
 
+    @property
+    def is_classvar(self) -> bool:
+        """Tell whether this expression represents a ClassVar.
+
+        Returns:
+            True or False.
+        """
+        return isinstance(self[0], Name) and self[0].full == "typing.ClassVar"
+
     @cached_property
     def non_optional(self) -> Expression:
         """Return the same expression as non-optional.

--- a/tests/test_visitor.py
+++ b/tests/test_visitor.py
@@ -329,7 +329,7 @@ def test_classvar_annotations() -> None:
         assert module["C.y"].value == "''"
 
         assert module["C.z"].annotation.full == "int"
-        assert module["C.z"].labels == {"class-attribute"}
+        assert module["C.z"].labels == {"class-attribute", "instance-attribute"}
         assert module["C.z"].value == "5"
 
         # This is syntactically valid, but semantically invalid


### PR DESCRIPTION
According to [PEP 526](https://peps.python.org/pep-0526/#class-and-instance-variable-annotations) annotated attributes in a class body are instance variables by default, unless explicitly overridden by using [`typing.ClassVar`](https://docs.python.org/3/library/typing.html#typing.ClassVar).

This PR makes 2 changes:
1. Honor `typing.ClassVar` in class variable annotations.
2. Merge the annotations in the class body and in `__init__()`.