### PR TITLE
fix: google docstrings warns section

### DIFF
--- a/src/griffe/docstrings/google.py
+++ b/src/griffe/docstrings/google.py
@@ -63,8 +63,8 @@ _section_kind = {
     "receives": DocstringSectionKind.receives,
     "examples": DocstringSectionKind.examples,
     "attributes": DocstringSectionKind.attributes,
-    "warns": DocstringSectionKind.attributes,
-    "warnings": DocstringSectionKind.attributes,
+    "warns": DocstringSectionKind.warns,
+    "warnings": DocstringSectionKind.warns,
 }
 
 BlockItem = Tuple[int, List[str]]


### PR DESCRIPTION
The `Warns` sections of google docstrings were incorrectly marked as `Attributes`. I saw this while trying to build a site using `mkdocstrings-python`.