### PR TITLE
feat: Support inheritance

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,10 +96,6 @@ See [the Loading data section](https://mkdocstrings.github.io/griffe/loading/) f
 
 ## Todo
 
-- Visitor/Inspector:
-    - Merging inherited members into class.
-        Needs to be able to post-process classes,
-        and to compute their MRO (C3Linearization, see docspec/pydocspec issues).
 - Extensions
     - Post-processing extensions
     - Third-party libraries we could provide support for:
@@ -111,7 +107,6 @@ See [the Loading data section](https://mkdocstrings.github.io/griffe/loading/) f
     - New Markdown-based format? For graceful degradation
 - Serializer:
     - Flat JSON
-    - JSON schema
 - API diff:
     - [ ] Mechanism to cache APIs? Should users version them, or store them somewhere (docs)?
     - [ ] Ability to return warnings (things that are not backward-compatibility-friendly)

--- a/docs/loading.md
+++ b/docs/loading.md
@@ -49,3 +49,96 @@ There are several ways to access members of an object:
 
 Most of the time, you will only use classes from the [`griffe.dataclasses`][griffe.dataclasses]
 and [`griffe.docstrings.dataclasses`][griffe.docstrings.dataclasses] modules.
+
+
+## Class inheritance
+
+TIP: **New in version 0.30**
+
+WARNING: **Inheritance support is experimental**
+Inheritance support was recently added, and might need
+some corrections before being fully usable.
+Don't hesitate to report any issue that arises
+from using inheritance support in Griffe.
+
+Griffe supports class inheritance, both when visiting and inspecting modules.
+
+To access members of a class that are inherited from base classes,
+use [`Object.inherited_members`][griffe.dataclasses.Object.inherited_members].
+If this is the first time you access inherited members, the base classes
+of the given class will be resolved and cached, then the MRO (Method Resolution Order)
+will be computed for these bases classes, and a dictionary of inherited members
+will be built and cached. Next times you access it, you'll get the cached dictionary.
+Make sure to only access `inherited_members` once everything is loaded by Griffe,
+to avoid computing things too early. Don't access inherited members
+in extensions, while visiting or inspecting a module.
+
+**Important:** only classes from already loaded packages
+will be used when computing inherited members.
+This gives users control over how deep into inheritance to go,
+by pre-loading packages from which you want to inherit members.
+For example, if `package_c.ClassC` inherits from `package_b.ClassB`,
+itself inheriting from `package_a.ClassA`, and you want
+to load `ClassB` members only:
+
+```python
+from griffe.loader import GriffeLoader
+
+loader = GriffeLoader()
+# note that we don't load package_a
+loader.load_module("package_b")
+loader.load_module("package_c")
+```
+
+If a base class cannot be resolved during computation
+of inherited members, Griffe logs a DEBUG message.
+
+If you want to access all members at once (both declared and inherited),
+use [`Object.all_members`][griffe.dataclasses.Object.all_members].
+
+If you want to access only declared members,
+use [`Object.members`][griffe.dataclasses.Object].
+
+Accessing [`Object.attributes`][griffe.dataclasses.Object.attributes],
+[`Object.functions`][griffe.dataclasses.Object.functions],
+[`Object.classes`][griffe.dataclasses.Object.classes] or
+[`Object.modules`][griffe.dataclasses.Object.modules]
+will trigger inheritance computation, so make sure to only call it
+once everything is loaded by Griffe. Don't access inherited members
+in extensions, while visiting or inspecting a module.
+
+### Limitations
+
+Currently, there are two limitations to our class inheritance support:
+
+1. when visiting (static analysis), some objects are not yet properly recognized as classes,
+    for example named tuples. If you inherit from a named tuple,
+    its members won't be added to the inherited members of the inheriting class.
+
+    ```python
+    MyTuple = namedtuple("MyTuple", "attr1 attr2")
+
+
+    class MyClass(MyTuple):
+        ...
+    ```
+
+2. when inspecting (dynamic analysis), ephemeral base classes won't be resolved,
+    and therefore their members won't appear in child classes. To circumvent that,
+    assign these dynamic classes to variables:
+
+    ```python
+    # instead of
+    class MyClass(namedtuple("MyTuple", "attr1 attr2")):
+        ...
+
+
+    # do
+    MyTuple = namedtuple("MyTuple", "attr1 attr2")
+
+
+    class MyClass(MyTuple):
+        ...
+    ```
+
+We will try to lift these limitations in the future.

--- a/src/griffe/agents/inspector.py
+++ b/src/griffe/agents/inspector.py
@@ -295,7 +295,11 @@ class Inspector(BaseInspector):
         Parameters:
             node: The node to inspect.
         """
-        bases = [base.__name__ for base in node.obj.__bases__ if base is not object]
+        bases = []
+        for base in node.obj.__bases__:
+            if base is object:
+                continue
+            bases.append(f"{base.__module__}.{base.__qualname__}")
 
         class_ = Class(
             name=node.name,

--- a/src/griffe/agents/inspector.py
+++ b/src/griffe/agents/inspector.py
@@ -266,7 +266,7 @@ class Inspector(BaseInspector):
                 else:
                     child_name = getattr(child.obj, "__name__", child.name)
                     target_path = f"{child_module_path}.{child_name}"
-                self.current[child.name] = Alias(child.name, target_path)
+                self.current.set_member(child.name, Alias(child.name, target_path))
             else:
                 self.inspect(child)
 
@@ -306,7 +306,7 @@ class Inspector(BaseInspector):
             docstring=self._get_docstring(node),
             bases=bases,
         )
-        self.current[node.name] = class_
+        self.current.set_member(node.name, class_)
         self.current = class_
         self.generic_inspect(node)
         self.current = self.current.parent  # type: ignore[assignment]
@@ -434,7 +434,7 @@ class Inspector(BaseInspector):
                 docstring=self._get_docstring(node),
             )
         obj.labels |= labels
-        self.current[node.name] = obj
+        self.current.set_member(node.name, obj)
 
     def inspect_attribute(self, node: ObjectNode) -> None:
         """Inspect an attribute.
@@ -481,7 +481,7 @@ class Inspector(BaseInspector):
             docstring=docstring,
         )
         attribute.labels |= labels
-        parent[node.name] = attribute
+        parent.set_member(node.name, attribute)
 
         if node.name == "__all__":
             parent.exports = set(node.obj)

--- a/src/griffe/agents/nodes.py
+++ b/src/griffe/agents/nodes.py
@@ -318,6 +318,13 @@ class ObjectNode:
         return f"ObjectNode(name={self.name!r})"
 
     @cached_property
+    def path(self) -> str:
+        """The object's (Python) path."""
+        if self.parent is None:
+            return self.name
+        return f"{self.parent.path}.{self.name}"
+
+    @cached_property
     def kind(self) -> ObjectKind:
         """Return the kind of this node.
 
@@ -508,6 +515,7 @@ class ObjectNode:
             and member is not type
             and member is not object
             and id(member) not in self._ids
+            and name in vars(self.obj)
         )
 
 

--- a/src/griffe/c3linear.py
+++ b/src/griffe/c3linear.py
@@ -1,0 +1,117 @@
+"""Compute method resolution order. Implements `Class.mro` attribute."""
+
+# Copyright (c) 2019 Vitaly R. Samigullin
+# Adapted from https://github.com/pilosus/c3linear
+# Adapted from https://github.com/tristanlatr/pydocspec
+
+from __future__ import annotations
+
+from itertools import islice
+from typing import Deque, TypeVar
+
+T = TypeVar("T")
+
+
+class _Dependency(Deque[T]):
+    """A class representing a (doubly-ended) queue of items."""
+
+    @property
+    def head(self) -> T | None:
+        """Head of the dependency."""
+        try:
+            return self[0]
+        except IndexError:
+            return None
+
+    @property
+    def tail(self) -> islice:
+        """Tail od the dependency.
+
+        The `islice` object is sufficient for iteration or testing membership (`in`).
+        """
+        try:
+            return islice(self, 1, self.__len__())
+        except (ValueError, IndexError):
+            return islice([], 0, 0)
+
+
+class _DependencyList:
+    """A class representing a list of linearizations (dependencies).
+
+    The last element of DependencyList is a list of parents.
+    It's needed  to the merge process preserves the local
+    precedence order of direct parent classes.
+    """
+
+    def __init__(self, *lists: list[T | None]) -> None:
+        """Initialize the list.
+
+        Parameters:
+            *lists: Lists of items.
+        """
+        self._lists = [_Dependency(lst) for lst in lists]
+
+    def __contains__(self, item: T) -> bool:
+        """Return True if any linearization's tail contains an item."""
+        return any(item in lst.tail for lst in self._lists)
+
+    def __len__(self) -> int:
+        size = len(self._lists)
+        return (size - 1) if size else 0
+
+    def __repr__(self) -> str:
+        return self._lists.__repr__()
+
+    @property
+    def heads(self) -> list[T | None]:
+        """Return the heads."""
+        return [lst.head for lst in self._lists]
+
+    @property
+    def tails(self) -> _DependencyList:
+        """Return self so that `__contains__` could be called."""
+        return self
+
+    @property
+    def exhausted(self) -> bool:
+        """True if all elements of the lists are exhausted."""
+        return all(len(x) == 0 for x in self._lists)
+
+    def remove(self, item: T | None) -> None:
+        """Remove an item from the lists.
+
+        Once an item removed from heads, the leftmost elements of the tails
+        get promoted to become the new heads.
+        """
+        for i in self._lists:
+            if i and i.head == item:
+                i.popleft()
+
+
+def c3linear_merge(*lists: list[T]) -> list[T]:
+    """Merge lists of lists in the order defined by the C3Linear algorithm.
+
+    Parameters:
+        *lists: Lists of items.
+
+    Returns:
+        The merged list of items.
+    """
+    result: list[T] = []
+    linearizations = _DependencyList(*lists)  # type: ignore[arg-type]
+
+    while True:
+        if linearizations.exhausted:
+            return result
+
+        for head in linearizations.heads:
+            if head and (head not in linearizations.tails):
+                result.append(head)  # type: ignore[arg-type]
+                linearizations.remove(head)
+
+                # Once candidate is found, continue iteration
+                # from the first element of the list.
+                break
+        else:
+            # Loop never broke, no linearization could possibly be found.
+            raise ValueError("Cannot compute C3 linearization")

--- a/src/griffe/collections.py
+++ b/src/griffe/collections.py
@@ -89,3 +89,7 @@ class ModulesCollection(GetMembersMixin, SetMembersMixin):
 
     def __contains__(self, item: Any) -> bool:
         return item in self.members
+
+    @property
+    def all_members(self) -> dict[str, Module]:  # noqa: D102
+        return self.members

--- a/src/griffe/dataclasses.py
+++ b/src/griffe/dataclasses.py
@@ -436,7 +436,11 @@ class Object(GetMembersMixin, SetMembersMixin, ObjectAliasMixin, SerializationMi
 
     @cached_property
     def inherited_members(self) -> dict[str, Alias]:
-        """Members that are inherited from base classes."""
+        """Members that are inherited from base classes.
+
+        This method is part of the consumer API:
+        do not use when producing Griffe trees!
+        """
         if not isinstance(self, Class):
             return {}
         inherited_members = {}
@@ -448,7 +452,11 @@ class Object(GetMembersMixin, SetMembersMixin, ObjectAliasMixin, SerializationMi
 
     @property
     def all_members(self) -> dict[str, Object | Alias]:
-        """All members (declared and inherited)."""
+        """All members (declared and inherited).
+
+        This method is part of the consumer API:
+        do not use when producing Griffe trees!
+        """
         return {**self.inherited_members, **self.members}
 
     @property
@@ -503,6 +511,9 @@ class Object(GetMembersMixin, SetMembersMixin, ObjectAliasMixin, SerializationMi
     def modules(self) -> dict[str, Module]:
         """Return the module members.
 
+        This method is part of the consumer API:
+        do not use when producing Griffe trees!
+
         Returns:
             A dictionary of modules.
         """
@@ -511,6 +522,9 @@ class Object(GetMembersMixin, SetMembersMixin, ObjectAliasMixin, SerializationMi
     @property
     def classes(self) -> dict[str, Class]:
         """Return the class members.
+
+        This method is part of the consumer API:
+        do not use when producing Griffe trees!
 
         Returns:
             A dictionary of classes.
@@ -521,6 +535,9 @@ class Object(GetMembersMixin, SetMembersMixin, ObjectAliasMixin, SerializationMi
     def functions(self) -> dict[str, Function]:
         """Return the function members.
 
+        This method is part of the consumer API:
+        do not use when producing Griffe trees!
+
         Returns:
             A dictionary of functions.
         """
@@ -529,6 +546,9 @@ class Object(GetMembersMixin, SetMembersMixin, ObjectAliasMixin, SerializationMi
     @property
     def attributes(self) -> dict[str, Attribute]:
         """Return the attribute members.
+
+        This method is part of the consumer API:
+        do not use when producing Griffe trees!
 
         Returns:
             A dictionary of attributes.
@@ -870,6 +890,10 @@ class Alias(ObjectAliasMixin):
         # not handled by __getattr__
         self.target[key] = value
 
+    def __delitem__(self, key: str | tuple[str, ...]):
+        # not handled by __getattr__
+        del self.target[key]
+
     def __len__(self) -> int:
         return 1
 
@@ -1072,6 +1096,15 @@ class Alias(ObjectAliasMixin):
     def resolve(self, name: str) -> str:  # noqa: D102
         return self.final_target.resolve(name)
 
+    def get_member(self, key: str | Sequence[str]) -> Object | Alias:  # noqa: D102
+        return self.final_target.get_member(key)
+
+    def set_member(self, key: str | Sequence[str], value: Object | Alias) -> None:  # noqa: D102
+        return self.final_target.set_member(key, value)
+
+    def del_member(self, key: str | Sequence[str]) -> None:  # noqa: D102
+        return self.final_target.del_member(key)
+
     # SPECIFIC MODULE/CLASS/FUNCTION/ATTRIBUTE PROXIES ---------------
 
     @property
@@ -1198,7 +1231,7 @@ class Alias(ObjectAliasMixin):
 
     def _resolve_target(self) -> None:
         try:
-            resolved = self.modules_collection[self.target_path]
+            resolved = self.modules_collection.get_member(self.target_path)
         except KeyError as error:
             raise AliasResolutionError(self) from error
         if resolved is self:
@@ -1435,7 +1468,11 @@ class Class(Object):
 
     @cached_property
     def resolved_bases(self) -> list[Object]:
-        """Resolved class bases."""
+        """Resolved class bases.
+
+        This method is part of the consumer API:
+        do not use when producing Griffe trees!
+        """
         resolved_bases = []
         for base in self.bases:
             if isinstance(base, str):

--- a/src/griffe/encoders.py
+++ b/src/griffe/encoders.py
@@ -141,7 +141,7 @@ def _load_parameter(obj_dict: dict[str, Any]) -> Parameter:
 def _load_module(obj_dict: dict[str, Any]) -> Module:
     module = Module(name=obj_dict["name"], filepath=Path(obj_dict["filepath"]), docstring=_load_docstring(obj_dict))
     for module_member in obj_dict.get("members", []):
-        module[module_member.name] = module_member
+        module.set_member(module_member.name, module_member)
     module.labels |= set(obj_dict.get("labels", ()))
     return module
 
@@ -156,7 +156,7 @@ def _load_class(obj_dict: dict[str, Any]) -> Class:
         bases=[_load_annotation(_) for _ in obj_dict["bases"]],
     )
     for class_member in obj_dict.get("members", []):
-        class_[class_member.name] = class_member
+        class_.set_member(class_member.name, class_member)
     class_.labels |= set(obj_dict.get("labels", ()))
     return class_
 

--- a/src/griffe/expressions.py
+++ b/src/griffe/expressions.py
@@ -167,6 +167,19 @@ class Expression(list):
         return str(self.non_optional).split("[", 1)[0].rsplit(".", 1)[-1].lower()
 
     @property
+    def without_subscript(self) -> Expression:
+        """The expression without the subscript part (if any).
+
+        For example, `Generic[T]` becomes `Generic`.
+        """
+        parts = []
+        for element in self:
+            if isinstance(element, str) and element == "[":
+                break
+            parts.append(element)
+        return Expression(*parts)
+
+    @property
     def is_tuple(self) -> bool:
         """Tell whether this expression represents a tuple.
 

--- a/src/griffe/extensions/hybrid.py
+++ b/src/griffe/extensions/hybrid.py
@@ -68,7 +68,7 @@ class HybridExtension(VisitorExtension):
 
     def visit(self, node: ast.AST) -> None:  # noqa: D102
         try:
-            just_visited = self.visitor.current[node.name]  # type: ignore[attr-defined]
+            just_visited = self.visitor.current.get_member(node.name)  # type: ignore[attr-defined]
         except (KeyError, AttributeError, TypeError):
             return
         if self.object_paths and not any(op.search(just_visited.path) for op in self.object_paths):

--- a/src/griffe/merger.py
+++ b/src/griffe/merger.py
@@ -49,14 +49,14 @@ def _merge_stubs_overloads(obj: Module | Class, stubs: Module | Class) -> None:
     for function_name, overloads in list(stubs.overloads.items()):
         if overloads:
             with suppress(KeyError):
-                obj[function_name].overloads = overloads
+                obj.get_member(function_name).overloads = overloads
         del stubs.overloads[function_name]
 
 
 def _merge_stubs_members(obj: Module | Class, stubs: Module | Class) -> None:
     for member_name, stub_member in stubs.members.items():
         if member_name in obj.members:
-            obj_member = obj[member_name]
+            obj_member = obj.get_member(member_name)
             with suppress(AliasResolutionError, CyclicAliasError):
                 if obj_member.kind is not stub_member.kind:
                     logger.debug(f"Cannot merge stubs of kind {stub_member.kind} into object of kind {obj_member.kind}")
@@ -68,7 +68,7 @@ def _merge_stubs_members(obj: Module | Class, stubs: Module | Class) -> None:
                     _merge_attribute_stubs(obj_member, stub_member)  # type: ignore[arg-type]
         else:
             stub_member.runtime = False
-            obj[member_name] = stub_member
+            obj.set_member(member_name, stub_member)
 
 
 def merge_stubs(mod1: Module, mod2: Module) -> Module:

--- a/src/griffe/mixins.py
+++ b/src/griffe/mixins.py
@@ -17,20 +17,6 @@ logger = get_logger(__name__)
 _ObjType = TypeVar("_ObjType")
 
 
-class GetMembersMixin:
-    """This mixin adds a `__getitem__` method to a class.
-
-    It makes it easier to access members of an object.
-    The method expects a `members` attribute/property to be available on the instance.
-    """
-
-    def __getitem__(self, key: str | Sequence[str]) -> Any:
-        parts = _get_parts(key)
-        if len(parts) == 1:
-            return self.members[parts[0]]  # type: ignore[attr-defined]
-        return self.members[parts[0]][parts[1:]]  # type: ignore[attr-defined]
-
-
 def _get_parts(key: str | Sequence[str]) -> Sequence[str]:
     if isinstance(key, str):
         if not key:
@@ -43,27 +29,154 @@ def _get_parts(key: str | Sequence[str]) -> Sequence[str]:
     return parts
 
 
+class GetMembersMixin:
+    """Mixin class to share methods for accessing members."""
+
+    def __getitem__(self, key: str | Sequence[str]) -> Any:
+        """Get a member with its name or path.
+
+        This method is part of the consumer API:
+        do not use when producing Griffe trees!
+
+        Members will be looked up in both declared members and inherited ones,
+        triggering computation of the latter.
+
+        Parameters:
+            key: The name or path of the member.
+
+        Examples:
+            >>> foo = griffe_object["foo"]
+            >>> bar = griffe_object["path.to.bar"]
+            >>> qux = griffe_object[("path", "to", "qux")]
+        """
+        parts = _get_parts(key)
+        if len(parts) == 1:
+            return self.all_members[parts[0]]  # type: ignore[attr-defined]
+        return self.all_members[parts[0]][parts[1:]]  # type: ignore[attr-defined]
+
+    def get_member(self, key: str | Sequence[str]) -> Any:
+        """Get a member with its name or path.
+
+        This method is part of the producer API:
+        you can use it safely while building Griffe trees
+        (for example in Griffe extensions).
+
+        Members will be looked up in declared members only, not inherited ones.
+
+        Parameters:
+            key: The name or path of the member.
+
+        Examples:
+            >>> foo = griffe_object["foo"]
+            >>> bar = griffe_object["path.to.bar"]
+            >>> bar = griffe_object[("path", "to", "bar")]
+        """
+        parts = _get_parts(key)
+        if len(parts) == 1:
+            return self.members[parts[0]]  # type: ignore[attr-defined]
+        return self.members[parts[0]].get_member(parts[1:])  # type: ignore[attr-defined]
+
+
 class DelMembersMixin:
-    """This mixin adds a `__delitem__` method to a class."""
+    """Mixin class to share methods for deleting members."""
 
     def __delitem__(self, key: str | Sequence[str]) -> None:
+        """Delete a member with its name or path.
+
+        This method is part of the consumer API:
+        do not use when producing Griffe trees!
+
+        Members will be looked up in both declared members and inherited ones,
+        triggering computation of the latter.
+
+        Parameters:
+            key: The name or path of the member.
+
+        Examples:
+            >>> del griffe_object["foo"]
+            >>> del griffe_object["path.to.bar"]
+            >>> del griffe_object[("path", "to", "qux")]
+        """
+        parts = _get_parts(key)
+        if len(parts) == 1:
+            name = parts[0]
+            try:
+                del self.members[name]  # type: ignore[attr-defined]
+            except KeyError:
+                del self.inherited_members[name]  # type: ignore[attr-defined]
+        else:
+            del self.all_members[parts[0]][parts[1:]]  # type: ignore[attr-defined]
+
+    def del_member(self, key: str | Sequence[str]) -> None:
+        """Delete a member with its name or path.
+
+        This method is part of the producer API:
+        you can use it safely while building Griffe trees
+        (for example in Griffe extensions).
+
+        Members will be looked up in declared members only, not inherited ones.
+
+        Parameters:
+            key: The name or path of the member.
+
+        Examples:
+            >>> griffe_object.del_member("foo")
+            >>> griffe_object.del_member("path.to.bar")
+            >>> griffe_object.del_member(("path", "to", "qux"))
+        """
         parts = _get_parts(key)
         if len(parts) == 1:
             name = parts[0]
             del self.members[name]  # type: ignore[attr-defined]
         else:
-            del self.members[parts[0]][parts[1:]]  # type: ignore[attr-defined]
+            self.members[parts[0]].del_member(parts[1:])  # type: ignore[attr-defined]
 
 
 class SetMembersMixin(DelMembersMixin):
-    """This mixin adds a `__setitem__` method to a class.
-
-    It makes it easier to set members of an object.
-    The method expects a `members` attribute/property to be available on the instance.
-    Each time a member is set, its `parent` attribute is set as well.
-    """
+    """Mixin class to share methods for setting members."""
 
     def __setitem__(self, key: str | Sequence[str], value: Object | Alias) -> None:
+        """Set a member with its name or path.
+
+        This method is part of the consumer API:
+        do not use when producing Griffe trees!
+
+        Parameters:
+            key: The name or path of the member.
+            value: The member.
+
+        Examples:
+            >>> griffe_object["foo"] = foo
+            >>> griffe_object["path.to.bar"] = bar
+            >>> griffe_object[("path", "to", "qux")] = qux
+        """
+        parts = _get_parts(key)
+        if len(parts) == 1:
+            name = parts[0]
+            self.members[name] = value  # type: ignore[attr-defined]
+            if self.is_collection:  # type: ignore[attr-defined]
+                value._modules_collection = self  # type: ignore[union-attr]
+            else:
+                value.parent = self  # type: ignore[assignment]
+        else:
+            self.members[parts[0]][parts[1:]] = value  # type: ignore[attr-defined]
+
+    def set_member(self, key: str | Sequence[str], value: Object | Alias) -> None:
+        """Set a member with its name or path.
+
+        This method is part of the producer API:
+        you can use it safely while building Griffe trees
+        (for example in Griffe extensions).
+
+        Parameters:
+            key: The name or path of the member.
+            value: The member.
+
+        Examples:
+            >>> griffe_object.set_member("foo", foo)
+            >>> griffe_object.set_member("path.to.bar", bar)
+            >>> griffe_object.set_member(("path", "to", "qux", qux)
+        """
         parts = _get_parts(key)
         if len(parts) == 1:
             name = parts[0]
@@ -88,7 +201,7 @@ class SetMembersMixin(DelMembersMixin):
             else:
                 value.parent = self  # type: ignore[assignment]
         else:
-            self.members[parts[0]][parts[1:]] = value  # type: ignore[attr-defined]
+            self.members[parts[0]].set_member(parts[1:], value)  # type: ignore[attr-defined]
 
 
 class ObjectAliasMixin:

--- a/src/griffe/tests.py
+++ b/src/griffe/tests.py
@@ -251,7 +251,7 @@ def vtree(*objects: Object, return_leaf: bool = False) -> Object:
     top = objects[0]
     leaf = top
     for obj in objects[1:]:
-        leaf[obj.name] = obj
+        leaf.set_member(obj.name, obj)
         leaf = obj
     return leaf if return_leaf else top
 
@@ -272,7 +272,7 @@ def htree(*objects: Object) -> Object:
         raise ValueError("At least one object must be provided")
     top = objects[0]
     for obj in objects[1:]:
-        top[obj.name] = obj
+        top.set_member(obj.name, obj)
     return top
 
 

--- a/tests/test_inheritance.py
+++ b/tests/test_inheritance.py
@@ -1,0 +1,195 @@
+"""Tests for class inheritance."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Callable
+
+import pytest
+
+from griffe.collections import ModulesCollection
+from griffe.tests import temporary_inspected_module, temporary_visited_module
+
+if TYPE_CHECKING:
+    from griffe.dataclasses import Class
+
+
+def _mro_paths(cls: Class) -> list[str]:
+    return [base.path for base in cls.mro()]
+
+
+@pytest.mark.parametrize("agent1", [temporary_visited_module, temporary_inspected_module])
+@pytest.mark.parametrize("agent2", [temporary_visited_module, temporary_inspected_module])
+def test_loading_inherited_members(agent1: Callable, agent2: Callable) -> None:
+    """Test basic class inheritance.
+
+    Parameters:
+        agent1: A parametrized agent to load a module.
+        agent2: A parametrized agent to load a module.
+    """
+    code1 = """
+        class A:
+            attr_from_a = 0
+            def method_from_a(self): ...
+
+        class B(A):
+            attr_from_a = 1
+            attr_from_b = 1
+            def method_from_b(self): ...
+    """
+    code2 = """
+        from module1 import B
+
+        class C(B):
+            attr_from_c = 2
+            def method_from_c(self): ...
+
+        class D(C):
+            attr_from_a = 3
+            attr_from_d = 3
+            def method_from_d(self): ...
+    """
+    inspection_options = {}
+    collection = ModulesCollection()
+
+    with agent1(code1, module_name="module1", modules_collection=collection) as module1:
+        if agent2 is temporary_inspected_module:
+            inspection_options["import_paths"] = [module1.filepath.parent]
+
+        with agent2(code2, module_name="module2", modules_collection=collection, **inspection_options) as module2:
+            collection["module1"] = module1
+            collection["module2"] = module2
+
+            classa = module1["A"]
+            classb = module1["B"]
+            classc = module2["C"]
+            classd = module2["D"]
+
+            assert classa in classb.resolved_bases
+            assert classb in classc.resolved_bases
+            assert classc in classd.resolved_bases
+
+            classd_mro = classd.mro()
+            assert classa in classd_mro
+            assert classb in classd_mro
+            assert classc in classd_mro
+
+            inherited_members = classd.inherited_members
+            assert "attr_from_a" not in inherited_members  # overwritten
+            assert "attr_from_b" in inherited_members
+            assert "attr_from_c" in inherited_members
+            assert "attr_from_d" not in inherited_members  # own-declared
+
+            assert "method_from_a" in inherited_members
+            assert "method_from_b" in inherited_members
+            assert "method_from_c" in inherited_members
+            assert "method_from_d" not in inherited_members  # own-declared
+
+            assert "attr_from_b" in classd.all_members
+
+
+@pytest.mark.parametrize("agent", [temporary_visited_module, temporary_inspected_module])
+def test_nested_class_inheritance(agent: Callable) -> None:
+    """Test nested class inheritance.
+
+    Parameters:
+        agent: A parametrized agent to load a module.
+    """
+    code = """
+        class A:
+            class B:
+                attr_from_b = 0
+
+        class C(A.B):
+            attr_from_c = 1
+    """
+    collection = ModulesCollection()
+    with agent(code, modules_collection=collection) as module:
+        collection["module"] = module
+        assert "attr_from_b" in module["C"].inherited_members
+
+    code = """
+        class OuterA:
+            class Inner: ...
+        class OuterB(OuterA):
+            class Inner(OuterA.Inner): ...
+        class OuterC(OuterA):
+            class Inner(OuterA.Inner): ...
+        class OuterD(OuterC):
+            class Inner(OuterC.Inner, OuterB.Inner): ...
+    """
+    collection = ModulesCollection()
+    with temporary_visited_module(code, modules_collection=collection) as module:
+        collection["module"] = module
+        assert _mro_paths(module["OuterD.Inner"]) == [
+            "module.OuterC.Inner",
+            "module.OuterB.Inner",
+            "module.OuterA.Inner",
+        ]
+
+
+@pytest.mark.parametrize(
+    ("classes", "cls", "expected_mro"),
+    [
+        (["A", "B(A)"], "B", ["A"]),
+        (["A", "B(A)", "C(A)", "D(B, C)"], "D", ["B", "C", "A"]),
+        (["A", "B(A)", "C(A)", "D(C, B)"], "D", ["C", "B", "A"]),
+        (["A(Z)"], "A", []),
+        (["A(str)"], "A", []),
+        (["A", "B(A)", "C(B)", "D(C)"], "D", ["C", "B", "A"]),
+        (["A", "B(A)", "C(B)", "D(C)", "E(A)", "F(B)", "G(F, E)", "H(G, D)"], "H", ["G", "F", "D", "C", "B", "E", "A"]),
+        (["A", "B(A[T])", "C(B[T])"], "C", ["B", "A"]),
+    ],
+)
+def test_computing_mro(classes: list[str], cls: str, expected_mro: list[str]) -> None:
+    """Test computing MRO.
+
+    Parameters:
+        classes: A list of classes inheriting from each other.
+        cls: The class to compute the MRO of.
+        expected_mro: The expected computed MRO.
+    """
+    code = "class " + ": ...\nclass ".join(classes) + ": ..."
+    collection = ModulesCollection()
+    with temporary_visited_module(code, modules_collection=collection) as module:
+        collection["module"] = module
+        assert _mro_paths(module[cls]) == [f"module.{base}" for base in expected_mro]
+
+
+@pytest.mark.parametrize(
+    ("classes", "cls"),
+    [
+        (["A", "B(A, A)"], "B"),
+        (["A(D)", "B", "C(A, B)", "D(C)"], "D"),
+    ],
+)
+def test_uncomputable_mro(classes: list[str], cls: str) -> None:
+    """Test uncomputable MRO.
+
+    Parameters:
+        classes: A list of classes inheriting from each other.
+        cls: The class to compute the MRO of.
+    """
+    code = "class " + ": ...\nclass ".join(classes) + ": ..."
+    collection = ModulesCollection()
+    with temporary_visited_module(code, modules_collection=collection) as module:
+        collection["module"] = module
+        with pytest.raises(ValueError, match="Cannot compute C3 linearization"):
+            _mro_paths(module[cls])
+
+
+def test_dynamic_base_classes() -> None:
+    """Test dynamic base classes."""
+    code = """
+        from collections import namedtuple
+        class A(namedtuple("B", "attrb")):
+            attra = 0
+    """
+    collection = ModulesCollection()
+    with temporary_visited_module(code, modules_collection=collection) as module:
+        collection["module"] = module
+        assert _mro_paths(module["A"]) == []  # not supported
+
+    collection = ModulesCollection()
+    with temporary_inspected_module(code, modules_collection=collection) as module:
+        collection["module"] = module
+        assert _mro_paths(module["A"]) == []  # not supported either

--- a/tests/test_stdlib.py
+++ b/tests/test_stdlib.py
@@ -20,7 +20,7 @@ def _access_inherited_members(obj: Object | Alias) -> None:
     except Exception:  # noqa: BLE001
         return
     if is_class:
-        assert obj.inherited_members is not None  # type: ignore[union-attr]
+        assert obj.inherited_members is not None
     else:
         for cls in obj.classes.values():
             _access_inherited_members(cls)
@@ -37,6 +37,5 @@ def test_fuzzing_on_stdlib() -> None:
             loader.load_module(package)
 
     loader.resolve_aliases(implicit=True, external=True)
-    # TODO: uncomment once inheritance feature is merged
-    # for module in loader.modules_collection.members.values():
-    #     _access_inherited_members(module)
+    for module in loader.modules_collection.members.values():
+        _access_inherited_members(module)


### PR DESCRIPTION
Closes #138
Closes #153 
Unblocks work on #96, https://github.com/mkdocstrings/python/issues/40, https://github.com/mkdocstrings/python/issues/13
Related to https://github.com/mkdocstrings/mkdocstrings/issues/459, https://github.com/mkdocstrings/mkdocstrings/issues/157, https://github.com/mkdocstrings/mkdocstrings/discussions/536

Tagging people who are probably interested: @samsja, @tazend, @cpcloud, @famura, @machow, @gab832, @analog-cbarber, @jayqi, @chrieke, @tristanlatr
Feel free to tag others. Also, subscribe to this PR to get future notifications: I'll explain the changes in this PR later so that we can discuss them. Or unsubscribe to stop getting notifications :slightly_smiling_face: 

---

Explanation:

- the inspector only picks up non-inherited members
- the visitor does not change at all
- inherited members are fetched on demand with `Object.inherited_members`
- inherited members are only fetched for classes, not instances (attributes), as instances have a type that can be used to point to the corresponding class
- to fetch inherited members, we resolve base classes (get the actual `Class`es representing them) and use C3 linearization to build the dict of inherited members according to Python's MRO (method resolution order)
- if multiple packages are involved in the inheritance, only members from pre-loaded packages (available in each module's `modules_collection`) are fetched
- this gives control to users, allowing to choose how deep in the class inheritance to go ("inherit from pydantic classes, but not further") by pre-loading packages/modules of their choice

---

mkdocstrings and the Python handler:

- we will be able to add an option `inherit_members: true/false`, false by default
- when false, the `members` attribute of objects will be used to filter members
- when true, the `all_members` property of objects will be used to filter members

---

Todo:

- [x] **tests!!!** :smile: 
    - [x] generic tests
    - [x] MRO tests
    - [x] dynamic class base tests
- [x] fuzzing on stdlib
- [x] fuzzing on popular packages
- [x] docs :nerd_face: 