### PR TITLE
fix: parse pth files with semi-colons as breaks

### DIFF
--- a/src/griffe/finder.py
+++ b/src/griffe/finder.py
@@ -332,13 +332,13 @@ def _handle_pth_file(path: Path) -> list[Path]:
     # Blank lines and lines beginning with # are skipped.
     # Lines starting with import (followed by space or tab) are executed.
     directories = []
-    for line in path.read_text(encoding="utf8").strip().splitlines(keepends=False):
+    for line in path.read_text(encoding="utf8").strip().replace(";", "\n").splitlines(keepends=False):
         line = line.strip()  # noqa: PLW2901
         if _re_import_line.match(line):
             editable_module = path.parent / f"{line[len('import'):].lstrip()}.py"
             with suppress(UnhandledEditableModuleError):
                 return _handle_editable_module(editable_module)
-        if line and not line.startswith("#") and ";" not in line and os.path.exists(line):
+        if line and not line.startswith("#") and os.path.exists(line):
             directories.append(Path(line))
     return directories
 

--- a/tests/test_finder.py
+++ b/tests/test_finder.py
@@ -94,6 +94,24 @@ def test_pth_file_handling(tmp_path: Path) -> None:
     assert directories == [Path("tests")]
 
 
+def test_pth_file_handling_with_semi_colon(tmp_path: Path) -> None:
+    """Assert .pth files are correctly handled.
+
+    Parameters:
+        tmp_path: Pytest fixture.
+    """
+    pth_file = tmp_path / "hello.pth"
+    pth_file.write_text(
+        dedent(
+            """
+            # comment
+            import thing; import\tthing; /doesnotexist; tests
+            """,
+        ),
+    )
+    directories = _handle_pth_file(pth_file)
+    assert directories == [Path("tests")]
+
 @pytest.mark.parametrize("editable_file_name", ["__editables_whatever.py", "_editable_impl_whatever.py"])
 def test_editables_file_handling(tmp_path: Path, editable_file_name: str) -> None:
     """Assert editable modules by `editables` are handled.


### PR DESCRIPTION
Addresses #172, by supporting semi-colons in pth files. Thanks for your quick response in the issue! Happy to make any changes :)