### PR TITLE
feat: Add `--version` and `-V` cli flag.

### DIFF
--- a/src/griffe/c3linear.py
+++ b/src/griffe/c3linear.py
@@ -25,7 +25,7 @@ class _Dependency(Deque[T]):
 
     @property
     def tail(self) -> islice:
-        """Tail od the dependency.
+        """Tail of the dependency.
 
         The `islice` object is sufficient for iteration or testing membership (`in`).
         """

--- a/src/griffe/cli.py
+++ b/src/griffe/cli.py
@@ -19,6 +19,7 @@ import logging
 import os
 import sys
 from datetime import datetime, timezone
+from importlib.metadata import version as get_version
 from pathlib import Path
 from typing import IO, TYPE_CHECKING, Any, Callable, Sequence
 
@@ -33,6 +34,8 @@ from griffe.git import _get_latest_tag, _get_repo_root, load_git
 from griffe.loader import GriffeLoader, load
 from griffe.logger import get_logger
 from griffe.stats import _format_stats
+
+version = get_version("griffe")
 
 if TYPE_CHECKING:
     from griffe.extensions import Extensions, ExtensionType
@@ -122,6 +125,7 @@ def get_parser() -> argparse.ArgumentParser:
 
     global_options = parser.add_argument_group(title="Global options")
     global_options.add_argument("-h", "--help", action="help", help=main_help)
+    global_options.add_argument("-V", "--version", action="version", version="%(prog)s " + version)
 
     def add_common_options(subparser: argparse.ArgumentParser) -> None:
         common_options = subparser.add_argument_group(title="Common options")

--- a/src/griffe/cli.py
+++ b/src/griffe/cli.py
@@ -19,7 +19,8 @@ import logging
 import os
 import sys
 from datetime import datetime, timezone
-from importlib.metadata import version as get_version
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as get_dist_version
 from pathlib import Path
 from typing import IO, TYPE_CHECKING, Any, Callable, Sequence
 
@@ -35,14 +36,19 @@ from griffe.loader import GriffeLoader, load
 from griffe.logger import get_logger
 from griffe.stats import _format_stats
 
-version = get_version("griffe")
-
 if TYPE_CHECKING:
     from griffe.extensions import Extensions, ExtensionType
 
 
 DEFAULT_LOG_LEVEL = os.getenv("GRIFFE_LOG_LEVEL", "INFO").upper()
 logger = get_logger(__name__)
+
+
+def _get_griffe_version() -> str:
+    try:
+        return get_dist_version("griffe")
+    except PackageNotFoundError:
+        return "0.0.0"
 
 
 def _print_data(data: str, output_file: str | IO | None) -> None:
@@ -125,7 +131,7 @@ def get_parser() -> argparse.ArgumentParser:
 
     global_options = parser.add_argument_group(title="Global options")
     global_options.add_argument("-h", "--help", action="help", help=main_help)
-    global_options.add_argument("-V", "--version", action="version", version="%(prog)s " + version)
+    global_options.add_argument("-V", "--version", action="version", version="%(prog)s " + _get_griffe_version())
 
     def add_common_options(subparser: argparse.ArgumentParser) -> None:
         common_options = subparser.add_argument_group(title="Common options")

--- a/src/griffe/mixins.py
+++ b/src/griffe/mixins.py
@@ -247,7 +247,7 @@ class SerializationMixin:
             **kwargs: Additional serialization options passed to encoder.
 
         Returns:
-            A string.
+            A JSON string.
         """
         from griffe.encoders import JSONEncoder  # avoid circular import
 

--- a/tests/test_inspector.py
+++ b/tests/test_inspector.py
@@ -49,7 +49,7 @@ def test_missing_dependency() -> None:
     with temporary_pypackage("package", ["module.py"]) as tmp_package:
         filepath = Path(tmp_package.path, "module.py")
         filepath.write_text("import missing")
-        with pytest.raises(ImportError):  # noqa: PT012,SIM117
+        with pytest.raises(ImportError):  # noqa: SIM117
             with suppress(ModuleNotFoundError):
                 inspect("package.module", filepath=filepath, import_paths=[tmp_package.tmpdir])
 


### PR DESCRIPTION
Hi,

This PR adds `--version` and `-V` command line flags to `griffe`.

Should I also add the version information to the common options?

This PR also closes #186.

I also added two commits fixing a typo in a docstring and improving the return description.

## Screenshot

![image](https://github.com/mkdocstrings/griffe/assets/47760695/fa43bcb2-535a-447d-b3b2-3a5c250c2ded)

