### PR TITLE
Fix dumping "filepath" to a dict when it is a list

### DIFF
--- a/src/griffe/dataclasses.py
+++ b/src/griffe/dataclasses.py
@@ -1300,7 +1300,12 @@ class Module(Object):
             A dictionary.
         """
         base = super().as_dict(**kwargs)
-        base["filepath"] = str(self._filepath) if self._filepath else None
+
+        filepath = None
+        if self._filepath:
+            filepath = [str(p) for p in self._filepath] if isinstance(self._filepath, list) else str(self.filepath)
+
+        base["filepath"] = filepath
         return base
 
 

--- a/src/griffe/dataclasses.py
+++ b/src/griffe/dataclasses.py
@@ -1300,12 +1300,12 @@ class Module(Object):
             A dictionary.
         """
         base = super().as_dict(**kwargs)
-
-        filepath = None
-        if self._filepath:
-            filepath = [str(p) for p in self._filepath] if isinstance(self._filepath, list) else str(self.filepath)
-
-        base["filepath"] = filepath
+        if isinstance(self._filepath, list):
+            base["filepath"] = [str(path) for path in self._filepath]
+        elif self._filepath:
+            base["filepath"] = str(self._filepath)
+        else:
+            base["filepath"] = None
         return base
 
 


### PR DESCRIPTION
While having a look at the source code, I realized that `filepath` was being incorrectly dumped as a string when being a list of paths, rather than as a list of strings.

```
"filepath": "[PosixPath('mod'), PosixPath('/home/davfsa/coding/test_mod')]"
```
vs
```
"filepath": [
    "mod",
    "/home/davfsa/coding/test_mod"
]
```

---

I have not added any tests, due to the lack of them in the module (at the time of writing). If it were needed, I could write it up :)
