### PR TITLE
Warnings are different from Warns

### DIFF
--- a/docs/docstrings.md
+++ b/docs/docstrings.md
@@ -488,7 +488,6 @@ depending on what you imported/defined in the current module.
 
 #### Warns
 
-- Aliases: Warnings
 - Multiple items allowed
 
 Warns sections allow to document warnings emitted by the following code.
@@ -512,6 +511,19 @@ TIP: **Warnings names are resolved using the function's scope.**
 You can document custom warnings, using the names available in the current scope,
 for example `my_warnings.MyCustomWarning` or `MyCustomWarning` directly,
 depending on what you imported/defined in the current module.
+
+#### Warnings
+
+Warnings sections allow to document cautions for the user.
+
+```python
+def foo():
+    """Foo.
+
+    Warnings:
+        Use this function with caution.
+    """
+```
 
 #### Yields
 
@@ -1219,7 +1231,6 @@ depending on what you imported/defined in the current module.
 
 #### Warns
 
-- Aliases: Warnings
 - Multiple items allowed
 
 Warns sections allow to document warnings emitted by the following code.
@@ -1245,6 +1256,20 @@ TIP: **Warnings names are resolved using the function's scope.**
 You can document custom warnings, using the names available in the current scope,
 for example `my_warnings.MyCustomWarning` or `MyCustomWarning` directly,
 depending on what you imported/defined in the current module.
+
+#### Warnings
+
+Warnings sections allow to document cautions for the user.
+
+```python
+def foo():
+    """Foo.
+
+    Warnings
+    --------
+    Use this function with caution.
+    """
+```
 
 #### Yields
 

--- a/src/griffe/docstrings/dataclasses.py
+++ b/src/griffe/docstrings/dataclasses.py
@@ -126,6 +126,10 @@ class DocstringWarn(DocstringElement):
     """This class represents a documented warn value."""
 
 
+class DocstringWarning(DocstringElement):
+    """This class represents a documented warning value."""
+
+
 class DocstringReturn(DocstringNamedElement):
     """This class represents a documented return value."""
 
@@ -278,11 +282,27 @@ class DocstringSectionWarns(DocstringSection):
         """Initialize the section.
 
         Parameters:
-            value: The section warnings.
+            value: The section warns.
             title: An optional title.
         """
         super().__init__(title)
         self.value: list[DocstringWarn] = value
+
+
+class DocstringSectionWarnings(DocstringSection):
+    """This class represents a warnings section."""
+
+    kind: DocstringSectionKind = DocstringSectionKind.warnings
+
+    def __init__(self, value: DocstringWarning, title: str | None = None) -> None:
+        """Initialize the section.
+
+        Parameters:
+            value: The section warnings.
+            title: An optional title.
+        """
+        super().__init__(title)
+        self.value: DocstringWarning = value
 
 
 class DocstringSectionReturns(DocstringSection):
@@ -474,7 +494,9 @@ __all__ = [
     "DocstringSectionReturns",
     "DocstringSectionText",
     "DocstringSectionWarns",
+    "DocstringSectionWarnings",
     "DocstringSectionYields",
     "DocstringWarn",
+    "DocstringWarning",
     "DocstringYield",
 ]

--- a/src/griffe/docstrings/google.py
+++ b/src/griffe/docstrings/google.py
@@ -30,9 +30,11 @@ from griffe.docstrings.dataclasses import (
     DocstringSectionReceives,
     DocstringSectionReturns,
     DocstringSectionText,
+    DocstringSectionWarnings,
     DocstringSectionWarns,
     DocstringSectionYields,
     DocstringWarn,
+    DocstringWarning,
     DocstringYield,
 )
 from griffe.docstrings.utils import parse_annotation, warning
@@ -70,7 +72,7 @@ _section_kind = {
     "classes": DocstringSectionKind.classes,
     "modules": DocstringSectionKind.modules,
     "warns": DocstringSectionKind.warns,
-    "warnings": DocstringSectionKind.warns,
+    "warnings": DocstringSectionKind.warnings,
 }
 
 BlockItem = Tuple[int, List[str]]
@@ -424,6 +426,19 @@ def _read_warns_section(
     return DocstringSectionWarns(warns), new_offset
 
 
+def _read_warnings_section(
+    docstring: Docstring,
+    *,
+    offset: int,
+    **options: Any,
+) -> tuple[DocstringSectionWarnings, int]:
+    description, new_offset = _read_block(docstring, offset=offset, **options)
+    return (
+        DocstringSectionWarnings(DocstringWarning(description=description)),
+        new_offset,
+    )
+
+
 def _read_returns_section(
     docstring: Docstring,
     *,
@@ -677,6 +692,7 @@ _section_reader = {
     DocstringSectionKind.other_parameters: _read_other_parameters_section,
     DocstringSectionKind.raises: _read_raises_section,
     DocstringSectionKind.warns: _read_warns_section,
+    DocstringSectionKind.warnings: _read_warnings_section,
     DocstringSectionKind.examples: _read_examples_section,
     DocstringSectionKind.attributes: _read_attributes_section,
     DocstringSectionKind.functions: _read_functions_section,

--- a/src/griffe/docstrings/numpy.py
+++ b/src/griffe/docstrings/numpy.py
@@ -47,9 +47,11 @@ from griffe.docstrings.dataclasses import (
     DocstringSectionReceives,
     DocstringSectionReturns,
     DocstringSectionText,
+    DocstringSectionWarnings,
     DocstringSectionWarns,
     DocstringSectionYields,
     DocstringWarn,
+    DocstringWarning,
     DocstringYield,
 )
 from griffe.docstrings.utils import parse_annotation, warning
@@ -74,6 +76,7 @@ _section_kind = {
     "receives": DocstringSectionKind.receives,
     "raises": DocstringSectionKind.raises,
     "warns": DocstringSectionKind.warns,
+    "warnings": DocstringSectionKind.warnings,
     "examples": DocstringSectionKind.examples,
     "attributes": DocstringSectionKind.attributes,
     "functions": DocstringSectionKind.functions,
@@ -547,6 +550,19 @@ def _read_warns_section(
     return DocstringSectionWarns(warns), new_offset
 
 
+def _read_warnings_section(
+    docstring: Docstring,
+    *,
+    offset: int,
+    **options: Any,
+) -> tuple[DocstringSectionWarnings, int]:
+    description, new_offset = _read_block(docstring, offset=offset, **options)
+    return (
+        DocstringSectionWarnings(DocstringWarning(description=description)),
+        new_offset,
+    )
+
+
 def _read_attributes_section(
     docstring: Docstring,
     *,
@@ -742,6 +758,7 @@ _section_reader = {
     DocstringSectionKind.deprecated: _read_deprecated_section,
     DocstringSectionKind.raises: _read_raises_section,
     DocstringSectionKind.warns: _read_warns_section,
+    DocstringSectionKind.warnings: _read_warnings_section,
     DocstringSectionKind.examples: _read_examples_section,
     DocstringSectionKind.attributes: _read_attributes_section,
     DocstringSectionKind.functions: _read_functions_section,

--- a/src/griffe/enumerations.py
+++ b/src/griffe/enumerations.py
@@ -17,6 +17,8 @@ class DocstringSectionKind(enum.Enum):
     raises = "raises"
     """Raises (exceptions) section."""
     warns = "warns"
+    """Warns section."""
+    warnings = "warnings"
     """Warnings section."""
     returns = "returns"
     """Returned value(s) section."""

--- a/src/griffe/mixins.py
+++ b/src/griffe/mixins.py
@@ -325,7 +325,7 @@ class SerializationMixin:
         return json.dumps(self, cls=JSONEncoder, full=full, **kwargs)
 
     @classmethod
-    def from_json(cls: type[_ObjType], json_string: str, **kwargs: Any) -> _ObjType:  # noqa: PYI019
+    def from_json(cls: type[_ObjType], json_string: str, **kwargs: Any) -> _ObjType:
         """Create an instance of this class from a JSON string.
 
         Parameters:

--- a/src/griffe/tests.py
+++ b/src/griffe/tests.py
@@ -24,7 +24,7 @@ if TYPE_CHECKING:
 TMPDIR_PREFIX = "griffe_"
 
 
-TmpPackage = namedtuple("TmpPackage", "tmpdir name path")  # noqa: PYI024
+TmpPackage = namedtuple("TmpPackage", "tmpdir name path")
 
 
 @contextmanager

--- a/tests/test_docstrings/test_google.py
+++ b/tests/test_docstrings/test_google.py
@@ -1496,3 +1496,22 @@ def test_reading_property_type_in_summary(parse_google: ParserType) -> None:
     assert retval.name == ""
     assert retval.annotation.name == "str"
     assert retval.description == ""
+
+
+def test_parse_warnings(
+    parse_google: ParserType,
+) -> None:
+    """Parse Warnings section with and without multiple items.
+
+    Parameters:
+        parse_google: Fixture parser.
+    """
+    docstring = """
+        Warnings:
+            A warning
+                is here.
+    """
+    sections, _ = parse_google(docstring)
+
+    assert len(sections) == 1
+    assert sections[0].value.description == "A warning\n    is here."


### PR DESCRIPTION
In numpy format,  contrary to `Warns`  sections, `Warnings` sections [do not have multiple items](https://numpydoc.readthedocs.io/en/latest/format.html#warnings).

The google format does not specify neither the `Warnings` nor the `Warns` section, but sphinx can parse it like for the numpy format.

This MR distinguish those sections such that `Warnings` sections have no items and docstrings that can be parsed by sphinx can also be parsed by mkdocs.