### PR TITLE
test: try to parse randomly generated code

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,6 +91,8 @@ tests = [
     "pytest-xdist>=2.4",
     "hypothesmith>=0.2.0",
     "jsonschema>=4.17.3",
+    "pysource-codegen>=0.4.1",
+    "pysource-minimize>=0.4.0",
 ]
 typing = [
     "mypy>=0.910",

--- a/tests/test_random_code.py
+++ b/tests/test_random_code.py
@@ -1,0 +1,33 @@
+
+
+
+from griffe.tests import temporary_visited_module
+from pysource_codegen import generate
+from pysource_minimize import minimize
+import pytest
+
+@pytest.mark.parametrize("seed",range(200))
+def test_visit_arbitrary_code(seed):
+    code=generate(seed)
+    
+    def contains_bug(code):
+        try:
+            with temporary_visited_module(code) as module:
+                return not bool(module)
+        except:
+            return True
+
+    if contains_bug(code):
+        
+        new_code=minimize(code,contains_bug)
+
+        print("the following code can not be parsed:")
+        print(new_code)
+
+        with temporary_visited_module(new_code) as module:
+            return module is None
+
+
+
+
+


### PR DESCRIPTION
Use pysource-codegen and pysource-minimize combined to find source code which can not be parsed.



some results:

``` python
@'some const text'[name_3]
async def name_5(): # type: some text
    pass
```

``` python
@lambda: name_5
class name_5:
    name_4 = name_0
```

``` python
@1[name_0]
async def name_3(): # type: ignoresome text
    pass
```

It might be that these examples are not as minimal as they could be (the type strings are propably not important). But I think that they are a good starting point.

