### PR TITLE
feat: numpy admonitions

### DIFF
--- a/tests/test_docstrings/test_numpy.py
+++ b/tests/test_docstrings/test_numpy.py
@@ -119,6 +119,88 @@ def test_doubly_indented_lines_in_section_items(parse_numpy: ParserType) -> None
     assert lines[-1].startswith(4 * " " + "- ")
 
 
+def test_text_section_after_parameters(parse_numpy: ParserType) -> None:
+    docstring = """
+        Parameters
+        ----------
+        a:
+            Some description
+        
+        A new text section
+    """
+
+    sections, _ = parse_numpy(docstring)
+    assert len(sections) == 2
+    assert sections[1].value == "A new text section"
+
+
+def test_text_section_between_sections(parse_numpy: ParserType) -> None:
+    docstring = """
+        Parameters
+        ----------
+        a:
+            Some description
+        
+        A new text section
+
+        Returns
+        -------
+        x: int
+    """
+
+    sections, _ = parse_numpy(docstring)
+    assert len(sections) == 3
+    assert sections[1].value == "A new text section"
+
+
+# =============================================================================================
+# Admonitions
+
+def test_admonition_see_also(parse_numpy: ParserType) -> None:
+    docstring = """
+    Summary text.
+
+    See Also
+    --------
+    some_function
+
+    more text
+    """
+
+    sections, _ = parse_numpy(docstring)
+    assert len(sections) == 2
+    assert sections[0].value == "Summary text."
+    assert sections[1].title == "See Also"
+    assert sections[1].value.description == "some_function\n\nmore text"
+
+
+def test_admonition_empty(parse_numpy: ParserType) -> None:
+    docstring = """
+    Summary text.
+
+    See Also
+    --------
+    """
+
+    sections, _ = parse_numpy(docstring)
+    assert len(sections) == 2
+    assert sections[0].value == "Summary text."
+    assert sections[1].title == "See Also"
+    assert sections[1].value.description == ""
+
+
+def test_admonition_empty_title_is_text_section(parse_numpy: ParserType) -> None:
+    docstring = """
+    Summary text.
+
+    ---
+    """
+
+    sections, _ = parse_numpy(docstring)
+    assert len(sections) == 1
+    assert sections[0].value == "Summary text.\n\n---"
+
+
 # =============================================================================================
 # Annotations
 def test_prefer_docstring_type_over_annotation(parse_numpy: ParserType) -> None:


### PR DESCRIPTION
This PR addresses #214, by parsing all unknown numpydoc sections as admonitions.

I'm not totally clear on the similarity / differences between numpydoc and google style docstrings, but hopefully this makes their parsed representations a bit closer to each other.

I think one big difference is that, a well-specified numpydoc docstring is made up of two things:

* initial description (DocstringSectionText)
* numpydoc sections, either
  - from spec and parsed by griffe. e.g. DocstringSectionParameters
  - not parsed by griffe, represented as DocstringSectionAdmonition

However, there's one more rule:

* When well defined numpydoc sections (e.g. DocstringSectionParameters) end, the content between them and the next section are represented with DocstringSectionText.

Here's my attempt to represent when DocstringSectionText, DocstringSectionAdmonition, and more defined sections like DocstringSectionParameters will appear.

```python
docstring = """

I am a DocstringTextSection summary.

Parameters
------------
a: int
    the a variable
b: float
    the b variable


I am a DocstringTextSection, because the well-defined parameters section
has ended.


See Also
---------
I am an DocstringAdmonitionSection, that griffe does not parse

Abcdefslkjs
------------
I am another DocstringAdmonitionSection
"""
```

Happy to tweak, enhance! Would love your thoughts on whether this seems to capture what DocstringSectionAdmonition is meant for. I tried to use the google docstring code as a reference..!