### PR TITLE
feat: Allow the use of *-stubs packages

### DIFF
--- a/src/griffe/finder.py
+++ b/src/griffe/finder.py
@@ -114,6 +114,9 @@ class ModuleFinder:
             module: The module name or path.
             try_relative_path: Whether to try finding the module as a relative path,
                 when the given module is not already a path.
+            find_stubs_package: Whether to search for stubs-only package.
+                If both the package and its stubs are found, they'll be merged together.
+                If only the stubs are found, they'll be used as the package itself.
 
         Raises:
             FileNotFoundError: When a Path was passed and the module could not be found:

--- a/src/griffe/git.py
+++ b/src/griffe/git.py
@@ -126,6 +126,7 @@ def load_git(
     lines_collection: LinesCollection | None = None,
     modules_collection: ModulesCollection | None = None,
     allow_inspection: bool = True,
+    find_stubs_package: bool = False,
 ) -> Module:
     """Load and return a module from a specific Git reference.
 
@@ -147,6 +148,9 @@ def load_git(
         lines_collection: A collection of source code lines.
         modules_collection: A collection of modules.
         allow_inspection: Whether to allow inspecting modules when visiting them is not possible.
+        find_stubs_package: Whether to search for stubs-only package.
+            If both the package and its stubs are found, they'll be merged together.
+            If only the stubs are found, they'll be used as the package itself.
 
     Returns:
         A loaded module.
@@ -166,6 +170,7 @@ def load_git(
             lines_collection=lines_collection,
             modules_collection=modules_collection,
             allow_inspection=allow_inspection,
+            find_stubs_package=find_stubs_package,
         )
 
 

--- a/src/griffe/loader.py
+++ b/src/griffe/loader.py
@@ -429,7 +429,12 @@ class GriffeLoader:
             return top_module
         if package.stubs:
             self.expand_wildcards(top_module)
-            stubs = self._load_module(package.name, package.stubs, submodules=False)
+            # If stubs are in the package itself, they have been merged while loading modules,
+            # so only the top-level init module needs to be merged still.
+            # If stubs are in another package (a stubs-only package),
+            # then we need to load the entire stubs package to merge everything.
+            submodules = package.stubs.parent != package.path.parent
+            stubs = self._load_module(package.name, package.stubs, submodules=submodules)
             return merge_stubs(top_module, stubs)
         return top_module
 

--- a/src/griffe/loader.py
+++ b/src/griffe/loader.py
@@ -441,7 +441,7 @@ class GriffeLoader:
             # so only the top-level init module needs to be merged still.
             # If stubs are in another package (a stubs-only package),
             # then we need to load the entire stubs package to merge everything.
-            submodules = package.stubs.parent != package.path.parent
+            submodules = submodules and package.stubs.parent != package.path.parent
             stubs = self._load_module(package.name, package.stubs, submodules=submodules)
             return merge_stubs(top_module, stubs)
         return top_module

--- a/src/griffe/loader.py
+++ b/src/griffe/loader.py
@@ -93,6 +93,7 @@ class GriffeLoader:
         *,
         submodules: bool = True,
         try_relative_path: bool = True,
+        find_stubs_package: bool = False,
     ) -> Module:
         """Load a module.
 
@@ -100,6 +101,9 @@ class GriffeLoader:
             module: The module name or path.
             submodules: Whether to recurse on the submodules.
             try_relative_path: Whether to try finding the module as a relative path.
+            find_stubs_package: Whether to search for stubs-only package.
+                If both the package and its stubs are found, they'll be merged together.
+                If only the stubs are found, they'll be used as the package itself.
 
         Raises:
             LoadingError: When loading a module failed for various reasons.
@@ -119,7 +123,11 @@ class GriffeLoader:
                 return self.modules_collection.get_member(module_name)
             raise LoadingError("Cannot load builtin module without inspection")
         try:
-            module_name, package = self.finder.find_spec(module, try_relative_path=try_relative_path)
+            module_name, package = self.finder.find_spec(
+                module,
+                try_relative_path=try_relative_path,
+                find_stubs_package=find_stubs_package,
+            )
         except ModuleNotFoundError:
             logger.debug(f"Could not find {module}")
             if self.allow_inspection:
@@ -627,6 +635,7 @@ def load(
     lines_collection: LinesCollection | None = None,
     modules_collection: ModulesCollection | None = None,
     allow_inspection: bool = True,
+    find_stubs_package: bool = False,
 ) -> Module:
     """Load and return a module.
 
@@ -659,6 +668,9 @@ def load(
         lines_collection: A collection of source code lines.
         modules_collection: A collection of modules.
         allow_inspection: Whether to allow inspecting modules when visiting them is not possible.
+        find_stubs_package: Whether to search for stubs-only package.
+            If both the package and its stubs are found, they'll be merged together.
+            If only the stubs are found, they'll be used as the package itself.
 
     Returns:
         A loaded module.
@@ -675,6 +687,7 @@ def load(
         module=module,
         submodules=submodules,
         try_relative_path=try_relative_path,
+        find_stubs_package=find_stubs_package,
     )
 
 

--- a/src/griffe/merger.py
+++ b/src/griffe/merger.py
@@ -56,12 +56,19 @@ def _merge_stubs_overloads(obj: Module | Class, stubs: Module | Class) -> None:
 def _merge_stubs_members(obj: Module | Class, stubs: Module | Class) -> None:
     for member_name, stub_member in stubs.members.items():
         if member_name in obj.members:
+            # We don't merge imported stub objects that already exist in the concrete module.
+            # Stub objects must be defined where they are exposed in the concrete package,
+            # not be imported from other stub modules.
+            if stub_member.is_alias:
+                continue
             obj_member = obj.get_member(member_name)
             with suppress(AliasResolutionError, CyclicAliasError):
                 if obj_member.kind is not stub_member.kind:
                     logger.debug(
                         f"Cannot merge stubs for {obj_member.path}: kind {stub_member.kind.value} != {obj_member.kind.value}",
                     )
+                elif obj_member.is_module:
+                    _merge_module_stubs(obj_member, stub_member)  # type: ignore[arg-type]
                 elif obj_member.is_class:
                     _merge_class_stubs(obj_member, stub_member)  # type: ignore[arg-type]
                 elif obj_member.is_function:


### PR DESCRIPTION
Small change to look for X-stubs first when looking for the X module. This better respects PEP 561.

Incidental fix to properly recognize a stubs only package as a package (and not a namespace package).

Please let me know if this is the correct approach (it works for my use case). I can also try to add tests if this is something that is mergeable. I tried to keep my changes to a minimal (being totally unfamiliar with the code).