### PR TITLE
fix: reporting the attribute who lost their value

### DIFF
--- a/src/griffe/diff.py
+++ b/src/griffe/diff.py
@@ -417,7 +417,8 @@ def _attribute_incompatibilities(old_attribute: Attribute, new_attribute: Attrib
     if old_attribute.value != new_attribute.value:
         if new_attribute.value is None:
             yield AttributeChangedValueBreakage(new_attribute, old_attribute.value, "unset")
-        yield AttributeChangedValueBreakage(new_attribute, old_attribute.value, new_attribute.value)
+        else:
+            yield AttributeChangedValueBreakage(new_attribute, old_attribute.value, new_attribute.value)
 
 
 def _alias_incompatibilities(

--- a/src/griffe/diff.py
+++ b/src/griffe/diff.py
@@ -415,6 +415,8 @@ def _attribute_incompatibilities(old_attribute: Attribute, new_attribute: Attrib
     # if old_attribute.annotation is not None and new_attribute.annotation is not None:
     #     if not is_subhint(new_attribute.annotation, old_attribute.annotation):
     if old_attribute.value != new_attribute.value:
+        if new_attribute.value is None:
+            new_attribute.value = "unset"
         yield AttributeChangedValueBreakage(new_attribute, old_attribute.value, new_attribute.value)
 
 

--- a/src/griffe/diff.py
+++ b/src/griffe/diff.py
@@ -416,7 +416,7 @@ def _attribute_incompatibilities(old_attribute: Attribute, new_attribute: Attrib
     #     if not is_subhint(new_attribute.annotation, old_attribute.annotation):
     if old_attribute.value != new_attribute.value:
         if new_attribute.value is None:
-            new_attribute.value = "unset"
+            yield AttributeChangedValueBreakage(new_attribute, old_attribute.value, "unset")
         yield AttributeChangedValueBreakage(new_attribute, old_attribute.value, new_attribute.value)
 
 

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -12,11 +12,6 @@ from griffe.tests import temporary_visited_module, temporary_visited_package
     ("old_code", "new_code", "expected_breakages"),
     [
         (
-            "a = True",
-            "a = False",
-            [BreakageKind.ATTRIBUTE_CHANGED_VALUE],
-        ),
-        (
             "class a(int, str): ...",
             "class a(int): ...",
             [BreakageKind.CLASS_REMOVED_BASE],
@@ -153,6 +148,11 @@ from griffe.tests import temporary_visited_module, temporary_visited_package
             "def a(x, y): ...",
             "def a(x): ...",
             [BreakageKind.PARAMETER_REMOVED],
+        ),
+        (
+            "class a:\n\tb: int | None = None",
+            "class a:\n\tb: int",
+            [BreakageKind.ATTRIBUTE_CHANGED_VALUE],
         ),
         (
             "def a() -> int: ...",

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -12,6 +12,11 @@ from griffe.tests import temporary_visited_module, temporary_visited_package
     ("old_code", "new_code", "expected_breakages"),
     [
         (
+            "a = True",
+            "a = False",
+            [BreakageKind.ATTRIBUTE_CHANGED_VALUE],
+        ),
+        (
             "class a(int, str): ...",
             "class a(int): ...",
             [BreakageKind.CLASS_REMOVED_BASE],


### PR DESCRIPTION
This PR Address the #218 issue. 

Describe the bug
For example, going from:

```
class A:
    b: int | None = None
```
to

```
class A:
    b: int
```
will report

`Attribute value was changed: None -> None`

Now modified to 

`Attribute value was changed: None -> unset`
