### PR TITLE
Add special case for NumpyDoc warnings section so they render as warning admonitions

### DIFF
--- a/src/griffe/docstrings/dataclasses.py
+++ b/src/griffe/docstrings/dataclasses.py
@@ -447,9 +447,6 @@ class DocstringSectionAdmonition(DocstringSection):
             text: The admonition text.
             title: An optional title.
         """
-        if kind == "warnings":
-            kind = "warning"
-
         super().__init__(title)
         self.value: DocstringAdmonition = DocstringAdmonition(annotation=kind, description=text)
 

--- a/src/griffe/docstrings/dataclasses.py
+++ b/src/griffe/docstrings/dataclasses.py
@@ -447,6 +447,9 @@ class DocstringSectionAdmonition(DocstringSection):
             text: The admonition text.
             title: An optional title.
         """
+        if kind == "warnings":
+            kind = "warning"
+
         super().__init__(title)
         self.value: DocstringAdmonition = DocstringAdmonition(annotation=kind, description=text)
 

--- a/src/griffe/docstrings/numpy.py
+++ b/src/griffe/docstrings/numpy.py
@@ -723,9 +723,15 @@ def _read_examples_section(
 
 def _append_section(sections: list, current: list[str], admonition_title: str) -> None:
     if admonition_title:
+        kind = admonition_title.lower().replace(" ", "-")
+        if kind in ("warnings", "notes"):
+            # NumpyDoc sections are pluralised but admonitions aren't.
+            # We can special-case these explicitly so that it renders
+            # as one would expect.
+            kind = kind[:-1]
         sections.append(
             DocstringSectionAdmonition(
-                kind=admonition_title.lower().replace(" ", "-"),
+                kind=kind,
                 text="\n".join(current).rstrip("\n"),
                 title=admonition_title,
             ),

--- a/tests/test_docstrings/test_numpy.py
+++ b/tests/test_docstrings/test_numpy.py
@@ -186,7 +186,7 @@ def test_isolated_dash_lines_do_not_create_sections(parse_numpy: ParserType) -> 
     assert sections[1].value.description == "Note contents.\n\n---\nText."
 
 
-def test_admonition_warnings_section(parse_numpy: ParserType) -> None:
+def test_admonition_warnings_special_case(parse_numpy: ParserType) -> None:
     """Test that the "Warnings" section renders as a warning admonition.
 
     Parameters:
@@ -208,6 +208,30 @@ def test_admonition_warnings_section(parse_numpy: ParserType) -> None:
     assert sections[1].title == "Warnings"
     assert sections[1].value.description == "Be careful!!!\n\nmore text"
     assert sections[1].value.annotation == "warning"
+
+
+def test_admonition_notes_special_case(parse_numpy: ParserType) -> None:
+    """Test that the "Warnings" section renders as a warning admonition.
+
+    Parameters:
+        parse_numpy: Fixture parser.
+    """
+    docstring = """
+    Summary text.
+
+    Notes
+    -----
+    Something noteworthy.
+
+    more text
+    """
+
+    sections, _ = parse_numpy(docstring)
+    assert len(sections) == 2
+    assert sections[0].value == "Summary text."
+    assert sections[1].title == "Notes"
+    assert sections[1].value.description == "Something noteworthy.\n\nmore text"
+    assert sections[1].value.annotation == "note"
 
 
 # =============================================================================================

--- a/tests/test_docstrings/test_numpy.py
+++ b/tests/test_docstrings/test_numpy.py
@@ -186,6 +186,30 @@ def test_isolated_dash_lines_do_not_create_sections(parse_numpy: ParserType) -> 
     assert sections[1].value.description == "Note contents.\n\n---\nText."
 
 
+def test_admonition_warnings_section(parse_numpy: ParserType) -> None:
+    """Test that the "Warnings" section renders as a warning admonition.
+
+    Parameters:
+        parse_numpy: Fixture parser.
+    """
+    docstring = """
+    Summary text.
+
+    Warnings
+    --------
+    Be careful!!!
+
+    more text
+    """
+
+    sections, _ = parse_numpy(docstring)
+    assert len(sections) == 2
+    assert sections[0].value == "Summary text."
+    assert sections[1].title == "Warnings"
+    assert sections[1].value.description == "Be careful!!!\n\nmore text"
+    assert sections[1].value.annotation == "warning"
+
+
 # =============================================================================================
 # Annotations
 def test_prefer_docstring_type_over_annotation(parse_numpy: ParserType) -> None:

--- a/tests/test_docstrings/test_numpy.py
+++ b/tests/test_docstrings/test_numpy.py
@@ -207,7 +207,7 @@ def test_admonition_warnings_special_case(parse_numpy: ParserType) -> None:
     assert sections[0].value == "Summary text."
     assert sections[1].title == "Warnings"
     assert sections[1].value.description == "Be careful!!!\n\nmore text"
-    assert sections[1].value.annotation == "warning"
+    assert sections[1].value.kind == "warning"
 
 
 def test_admonition_notes_special_case(parse_numpy: ParserType) -> None:

--- a/tests/test_docstrings/test_numpy.py
+++ b/tests/test_docstrings/test_numpy.py
@@ -231,7 +231,7 @@ def test_admonition_notes_special_case(parse_numpy: ParserType) -> None:
     assert sections[0].value == "Summary text."
     assert sections[1].title == "Notes"
     assert sections[1].value.description == "Something noteworthy.\n\nmore text"
-    assert sections[1].value.annotation == "note"
+    assert sections[1].value.kind == "note"
 
 
 # =============================================================================================


### PR DESCRIPTION
This PR fixes a bug in the NumpyDoc parser where the Warnings section would render as a note admonition. They now render as warning admonitions.

I felt bad opening an issue about this after accusing the NumpyDoc parser of being buggy yesterday, so thought I'd at least contribute this one myself 😄 