### PR TITLE
fix: Don't turn items annotated as InitVar into dataclass members

### DIFF
--- a/src/griffe/extensions/dataclasses.py
+++ b/src/griffe/extensions/dataclasses.py
@@ -176,6 +176,17 @@ def _set_dataclass_init(class_: Class) -> None:
     class_.set_member("__init__", init)
 
 
+def _del_members_annotated_as_initvar(class_: Class) -> None:
+    # Definitions annotated as InitVar are not class members
+    attributes = cast(
+        list[Attribute],
+        [member for member in class_.members.values() if member.is_attribute]
+    )
+    for attribute in attributes:
+        if isinstance(attribute.annotation, Expr) and attribute.annotation.canonical_path == "dataclasses.InitVar":
+            class_.del_member(attribute.name)
+
+
 def _apply_recursively(mod_cls: Module | Class, processed: set[str]) -> None:
     if mod_cls.canonical_path in processed:
         return
@@ -183,6 +194,7 @@ def _apply_recursively(mod_cls: Module | Class, processed: set[str]) -> None:
     if isinstance(mod_cls, Class):
         if "__init__" not in mod_cls.members:
             _set_dataclass_init(mod_cls)
+            _del_members_annotated_as_initvar(mod_cls)
         for member in mod_cls.members.values():
             if not member.is_alias and member.is_class:
                 _apply_recursively(member, processed)  # type: ignore[arg-type]

--- a/src/griffe/extensions/dataclasses.py
+++ b/src/griffe/extensions/dataclasses.py
@@ -178,10 +178,7 @@ def _set_dataclass_init(class_: Class) -> None:
 
 def _del_members_annotated_as_initvar(class_: Class) -> None:
     # Definitions annotated as InitVar are not class members
-    attributes = cast(
-        list[Attribute],
-        [member for member in class_.members.values() if member.is_attribute]
-    )
+    attributes = [member for member in class_.members.values() if isinstance(member, Attribute)]
     for attribute in attributes:
         if isinstance(attribute.annotation, Expr) and attribute.annotation.canonical_path == "dataclasses.InitVar":
             class_.del_member(attribute.name)

--- a/tests/test_dataclasses.py
+++ b/tests/test_dataclasses.py
@@ -283,7 +283,6 @@ def test_parameters_annotated_as_initvar() -> None:
 
     But if __init__ is defined, InitVar has no effect.
     """
-
     code = """
     from dataclasses import dataclass, InitVar
 
@@ -303,10 +302,10 @@ def test_parameters_annotated_as_initvar() -> None:
     """
 
     with temporary_visited_package("package", {"__init__.py": code}) as module:
-        PointA = module["PointA"]
-        assert ["self", "x", "y", "z"] == [p.name for p in PointA.parameters]
-        assert ["x", "y", "__init__"] == [name for name in PointA.members]
+        point_a = module["PointA"]
+        assert ["self", "x", "y", "z"] == [p.name for p in point_a.parameters]
+        assert ["x", "y", "__init__"] == list(point_a.members)
 
-        PointB = module["PointB"]
-        assert ["self", "r"] == [p.name for p in PointB.parameters]
-        assert ["x", "y", "z", "__init__"] == [name for name in PointB.members]
+        point_b = module["PointB"]
+        assert ["self", "r"] == [p.name for p in point_b.parameters]
+        assert ["x", "y", "z", "__init__"] == list(point_b.members)


### PR DESCRIPTION
This PR addresses the case of dataclass [init-only variables](https://docs.python.org/3/library/dataclasses.html#init-only-variables) also being treated as class members. i.e

```python
from dataclasses import dataclass, InitVar

@dataclass
class Point:
    x: float
    y: float
    z: InitVar[float]
```

is equivalent (compatible) to


```python
class Point:
    def __init__(self, x: float, y: float, z: float):
       self.x = x
       self.y = y
```

The class is not expected to have member `z` (`instance.z`).
