### PR TITLE
fix: Attributes without annotations cannot be parameters

### DIFF
--- a/src/griffe/extensions/dataclasses.py
+++ b/src/griffe/extensions/dataclasses.py
@@ -80,6 +80,10 @@ def _dataclass_parameters(class_: Class) -> list[Parameter]:
         if member.is_attribute:
             member = cast(Attribute, member)
 
+            # All dataclass parameters have annotations
+            if member.annotation is None:
+                continue
+
             # Attributes that have labels for these characteristics are
             # not class parameters:
             #   - @property

--- a/tests/test_dataclasses.py
+++ b/tests/test_dataclasses.py
@@ -421,3 +421,27 @@ def test_dataclass_parameter_docstrings() -> None:
         assert param_b.docstring.value == "Parameter b"
         assert param_c.docstring is None
         assert param_d.docstring.value == "Parameter d"
+
+
+def test_attributes_that_have_no_annotations() -> None:
+    """Dataclass attributes that have no annotatations are not parameters."""
+    code = """
+        from dataclasses import dataclass, field
+
+        @dataclass
+        class Base:
+            a: int
+            b: str = field(init=False)
+            c = 3  # class attribute
+
+        @dataclass
+        class Derived(Base):
+            a = 1  # no effect on the parameter status of a
+            b = "b"  # inherited non-parameter
+            d: float = 4
+    """
+    with temporary_visited_package("package", {"__init__.py": code}) as module:
+        base_params = [p.name for p in module["Base"].parameters]
+        derived_params = [p.name for p in module["Derived"].parameters]
+        assert base_params == ["self", "a"]
+        assert derived_params == ["self", "a", "d"]


### PR DESCRIPTION
All dataclass parameters have annotations. When determining
which of the attributes of dataclass are parameters, we
explicitly check against that condition. This help us filter
out obvious non-candidates that may otherwise fall through.
