### PR TITLE
Support non-multiple and non-named values in Yields and Receives

### DIFF
--- a/docs/reference/docstrings.md
+++ b/docs/reference/docstrings.md
@@ -141,9 +141,14 @@ The parser accepts a few options:
 - `ignore_init_summary`: Ignore the first line in `__init__` methods' docstrings.
     Useful when merging `__init__` docstring into class' docstrings
     with mkdocstrings-python's [`merge_init_into_class`][merge_init] option. Default: false.
-- `returns_multiple_items`: Parse [Returns sections](#google-section-returns) as if they contain multiple items.
+- `returns_multiple_items`: Parse [Returns sections](#google-section-returns) and [Yields sections](#google-section-yields) as if they contain multiple items.
     It means that continuation lines must be indented. Default: true.
-- `returns_named_value`: Whether to parse `thing: Description` in [Returns sections](#google-section-returns) as a name and description,
+- `returns_named_value`: Whether to parse `thing: Description` in [Returns sections](#google-section-returns) and [Yields sections](#google-section-yields) as a name and description,
+    rather than a type and description. When true, type must be wrapped in parentheses: `(int): Description.`.
+    When false, parentheses are optional but the items cannot be named: `int: Description`. Default: true.
+- `receives_multiple_items`: Parse [Receives sections](#google-section-receives) as if they contain multiple items.
+    It means that continuation lines must be indented. Default: true.
+- `receives_named_value`: Whether to parse `thing: Description` in [Receives sections](#google-section-receives) as a name and description,
     rather than a type and description. When true, type must be wrapped in parentheses: `(int): Description.`.
     When false, parentheses are optional but the items cannot be named: `int: Description`. Default: true.
 - `returns_type_in_property_summary`: Whether to parse the return type of properties
@@ -580,6 +585,22 @@ def foo() -> Iterator[tuple[float, float, datetime]]:
     ...
 ```
 
+You have to indent each continuation line when documenting yielded values,
+even if there's only one value yielded:
+
+```python
+"""Foo.
+
+Yields:
+    partial_result: Some partial result.
+        A longer description of details and other information
+        for this partial result.
+"""
+```
+
+If you don't want to indent continuation lines for the only yielded value,
+use the [`returns_multiple_items=False`](#google-options) parser option.
+
 Type annotations can as usual be overridden using types in parentheses
 in the docstring itself:
 
@@ -592,6 +613,22 @@ Yields:
     t (int): Timestamp.
 """
 ```
+
+If you want to specify the type without a name, you still have to wrap the type in parentheses:
+
+```python
+"""Foo.
+
+Yields:
+    (int): Absissa.
+    (int): Ordinate.
+    (int): Timestamp.
+"""
+```
+
+If you don't want to wrap the type in parentheses,
+use the [`returns_named_value=False`](#google-options) parser option.
+Setting it to false will disallow specifying a name.
 
 TIP: **Types in docstrings are resolved using the docstrings' parent scope.**  
 See previous tips for types in docstrings.
@@ -663,6 +700,22 @@ def foo() -> Generator[int, tuple[str, bool], None]:
     ...
 ```
 
+You have to indent each continuation line when documenting received values,
+even if there's only one value received:
+
+```python
+"""Foo.
+
+Receives:
+    data: Input data.
+        A longer description of what this data actually is,
+        and what it isn't.
+"""
+```
+
+If you don't want to indent continuation lines for the only received value,
+use the [`receives_multiple_items=False`](#google-options) parser option.
+
 Type annotations can as usual be overridden using types in parentheses
 in the docstring itself:
 
@@ -674,6 +727,21 @@ Receives:
     flag (int): Some flag.
 """
 ```
+
+If you want to specify the type without a name, you still have to wrap the type in parentheses:
+
+```python
+"""Foo.
+
+Receives:
+    (ModeEnum): Some mode.
+    (int): Some flag.
+"""
+```
+
+If you don't want to wrap the type in parentheses,
+use the [`receives_named_value=False`](#google-options) parser option.
+Setting it to false will disallow specifying a name.
 
 TIP: **Types in docstrings are resolved using the docstrings' parent scope.**  
 See previous tips for types in docstrings.


### PR DESCRIPTION
This PR fixes https://github.com/mkdocstrings/griffe/issues/263 by applying the same logic from the `Returns` section parser to the `Yields` and `Receives` parser.  The `Yields` section parser is configured with the same two configuration variables `returns_multiple_items` and `returns_named_value`, whereas the `Receives` section parser is configured via the new `receives_multiple_items` and `receives_named_value` configuration variables. Furthermore, the parsing of multiple or single docstring block contents, of named or unnamed parameters, and the unpacking of generator and/or tuple return annotations has been refactored into separate functions.

---

<b>Contents:</b>

- 8a78e68e7702d5b874daa21aeca58943eb9cf7d6 duplicates the non-multiple return and the named value parsing support for the `Yields` and `Receives` section parsers, essentially via copy-and-paste. Includes suitable tests, based on the `Returns` section tests.
- 756118fc0da4866c80fde0b456cbb497124c0a18 implements the aforementioned refactored functions. This commit is functionally optional, but hopefully useful with respect to future ease of maintenance.
- e01447a5980ca2c6e94c93f8df7618deb59d627a fixes linting errors.
- 8e7cb30fac0df5e619da94b102d5c88de0b36a18 adds documentation for the above features.