### PR TITLE
Fix: f-string inclusion in debug msg

### DIFF
--- a/src/_griffe/loader.py
+++ b/src/_griffe/loader.py
@@ -261,8 +261,7 @@ class GriffeLoader:
                 resolved |= next_resolved
                 unresolved |= next_unresolved
             logger.debug(
-                "Iteration %s finished, {len(resolved)} aliases resolved, still {len(unresolved)} to go",
-                iteration,
+                f"Iteration {iteration} finished, {len(resolved)} aliases resolved, still {len(unresolved)} to go",
             )
         return unresolved, iteration
 

--- a/src/_griffe/loader.py
+++ b/src/_griffe/loader.py
@@ -261,7 +261,10 @@ class GriffeLoader:
                 resolved |= next_resolved
                 unresolved |= next_unresolved
             logger.debug(
-                f"Iteration {iteration} finished, {len(resolved)} aliases resolved, still {len(unresolved)} to go",
+                "Iteration %s finished, %s aliases resolved, still %s to go",
+                iteration,
+                len(resolved),
+                len(unresolved),
             )
         return unresolved, iteration
 


### PR DESCRIPTION
Thank you for all the work on mkdocstrings! Tiny fix, I noticed that some of the messages read like

```
DEBUG   -  griffe: Iteration 1 finished, {len(resolved)} aliases resolved, still {len(unresolved)} to go
```