### PR TITLE
fix: Change `test_load_builtin_modules` to use module present in PyPy

### DIFF
--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -354,10 +354,10 @@ def test_load_builtin_modules() -> None:
     loader = GriffeLoader()
     loader.load("_ast")
     loader.load("_collections")
-    loader.load("_json")
+    loader.load("_operator")
     assert "_ast" in loader.modules_collection
     assert "_collections" in loader.modules_collection
-    assert "_json" in loader.modules_collection
+    assert "_operator" in loader.modules_collection
 
 
 def test_resolve_aliases_of_builtin_modules() -> None:


### PR DESCRIPTION
Change `test_load_builtin_modules` to use `_operator` rather than `_json`, to fix test failure on PyPy.  PyPy does not feature a `_json` module, whereas `_operator` is present both on CPython and on PyPy.

Fixes #362