### PR TITLE
chore(makefile): set help target as default goal

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,13 @@
 # the `make` command will point at the `scripts/make` shell script.
 # This Makefile is just here to allow auto-completion in the terminal.
 
+# The first target in the makefile is the default goal when no targets are specified.
+# Having "help:" here above without any rule (nothing to do specified with a tab)
+# only adds dependencies to that target, that is defined through "$(actions):".
+# .DEFAULT_GOAL is not necessary here, but is really explicit about what is going on.
+help:
+.DEFAULT_GOAL: help
+
 actions = \
 	allrun \
 	changelog \


### PR DESCRIPTION
Add explicit comments explaining the purpose of the help target and .DEFAULT_GOAL. This improves readability and makes the Makefile's behavior more transparent.

See https://www.gnu.org/software/make/manual/html_node/Goals.html and https://stackoverflow.com/a/43719512/19489416

The most impactful effect is that now, simply calling "make" will show the help, instead of a weird error (weird for newcomers, like me this weekend). If you like this pattern, feel free to apply it to the other repos that use the same structure.
Before:
![image](https://github.com/user-attachments/assets/a4847f75-964a-4a64-893f-9f6b518c4447)
After:
![image](https://github.com/user-attachments/assets/3ad4959a-7081-44d9-a568-1b2e97110c2e)


<details><summary>Console output as text for easier searching:</summary>
<p>

```
vscode ➜ /workspaces/griffe (makefile-help-default) $ make
Available commands
  help                  Print this help. Add task name to print help.
  setup                 Setup all virtual environments (install dependencies).
  run                   Run a command in the default virtual environment.
  multirun              Run a command for all configured Python versions.
  allrun                Run a command in all virtual environments.
  3.x                   Run a command in the virtual environment for Python 3.x.
  clean                 Delete build artifacts and cache files.
  vscode                Configure VSCode to work on this project.

Available tasks
  build                 Build source and wheel distributions.
  changelog             Update the changelog in-place with latest commits.
  check                 Check it all!
  check-api             Check for API breaking changes.
  check-docs            Check if the documentation builds correctly.
  check-quality         Check the code quality.
  check-types           Check that the code is correctly typed.
  coverage              Report coverage as text and HTML.
  docs                  Serve the documentation (localhost:8000).
  docs-deploy           Deploy the documentation to GitHub pages.
  format                Run formatting tools on the code.
  fuzz                  Fuzz Griffe against generated Python code.
  publish               Publish source and wheel distributions to PyPI.
  release               Release a new version of the project.
  test                  Run the test suite.
vscode ➜ /workspaces/griffe (makefile-help-default) $ 
vscode ➜ /workspaces/griffe (main) $ make
Traceback (most recent call last):
  File "/workspaces/griffe/scripts/make", line 318, in <module>
    sys.exit(main(sys.argv[1:]))
             ~~~~^^^^^^^^^^^^^^
  File "/workspaces/griffe/scripts/make", line 288, in main
    allrun(*args)
    ~~~~~~^^^^^^^
TypeError: allrun() missing 1 required positional argument: 'cmd'
make: *** [Makefile:28: allrun] Error 1
vscode ➜ /workspaces/griffe (main) $ 
``` 


</p>
</details> 