### PR TITLE
fix: Allow `ExprName.parent` to be of type `griffe.Function`

### DIFF
--- a/src/_griffe/expressions.py
+++ b/src/_griffe/expressions.py
@@ -23,7 +23,7 @@ if TYPE_CHECKING:
     from collections.abc import Iterable, Iterator, Sequence
     from pathlib import Path
 
-    from _griffe.models import Class, Module
+    from _griffe.models import Class, Function, Module
 
 
 def _yield(element: str | Expr | tuple[str | Expr, ...], *, flat: bool = True) -> Iterator[str | Expr]:
@@ -599,7 +599,7 @@ class ExprName(Expr):  # noqa: PLW1641
 
     name: str
     """Actual name."""
-    parent: str | ExprName | Module | Class | None = None
+    parent: str | ExprName | Module | Class | Function | None = None
     """Parent (for resolution in its scope)."""
 
     def __eq__(self, other: object) -> bool:


### PR DESCRIPTION
Fixed typing annotation following discussion comment: https://github.com/mkdocstrings/griffe/discussions/391#discussioncomment-13698603