### PR TITLE
feat: Enhance parameter parsing to handle invalid type info and add related tests

### DIFF
--- a/src/_griffe/docstrings/sphinx.py
+++ b/src/_griffe/docstrings/sphinx.py
@@ -150,6 +150,12 @@ def _read_parameter(
             docstring,
         )
         name = parsed_directive.directive_parts[2]
+    elif len(parsed_directive.directive_parts) > 3:  # noqa: PLR2004
+        # Ignoring type info, only a type with a single word is valid
+        # https://www.sphinx-doc.org/en/master/usage/domains/python.html#info-field-lists
+        name = parsed_directive.directive_parts[-1]
+        if warnings:
+            docstring_warning(docstring, 0, f"Failed to parse field directive from '{parsed_directive.line}'")
     else:
         if warnings:
             docstring_warning(docstring, 0, f"Failed to parse field directive from '{parsed_directive.line}'")


### PR DESCRIPTION
This PR enhances the parsing of `:param xxxx yyyy:` tags in the sphinx style docstrings, when the type in the middle is invalid because of added spaces (not single word).

According [to these sphinx docs](https://www.sphinx-doc.org/en/master/usage/domains/python.html#info-field-lists), the types and parameters can be combined only when there are no spaces in the type: 

> It is also possible to combine parameter type and description, if the type is a single word, like this:
> ```rest
> :param int priority: The priority of the message, can be a number 1-5
> ```

When there are spaces, there are more than 3 elements in the `directive_parts` of the `parsed_directive`. Before this PR, the whole parameter would be skipped (optionally showing warnings) and just not shown in the rendered docs, and it is quite unexpected, as there was some valid description text added. Apart from the type information, there isn't any problem in parsing the directive, if the last part (last element of the list) is the parameter and isn't duplicated and is part of the signature. These two checks are already made below.

What this PR does, is to simply ignore the wrong type information (still outputting a warning), but at least keep the parameter name and the text added, so it isn't discarded completely. I consider the typing information as a supplement in the documentation of a function, but missing a parameter completely is far worse.
