### PR TITLE
ReST-style docstring implementation

### DIFF
--- a/docs/guide/users/how-to/set-docstring-styles.md
+++ b/docs/guide/users/how-to/set-docstring-styles.md
@@ -45,7 +45,7 @@ import griffe
 
 
 class ApplyDocstringStyle(griffe.Extension):
-    def __init__(self, regex: str = "<!-- style: (google|numpy|sphinx) -->") -> None:
+    def __init__(self, regex: str = "<!-- style: (google|numpy|rest|sphinx) -->") -> None:
          self.regex = re.compile(regex)
 
     def on_instance(self, *, obj: griffe.Object, **kwargs) -> None:
@@ -74,7 +74,7 @@ import griffe
 
 
 class ApplyDocstringStyle(griffe.Extension):
-    def __init__(self, regex: str = ".*# style: (google|numpy|sphinx)$") -> None:
+    def __init__(self, regex: str = ".*# style: (google|numpy|rest|sphinx)$") -> None:
          self.regex = re.compile(regex)
 
     def on_instance(self, *, obj: griffe.Object, **kwargs) -> None:
@@ -127,6 +127,7 @@ plugins:
                 path.to.obj2: numpy
                 path.to.obj3.*: sphinx
                 path.to.obj4*: google
+                path.to.obj5: rest
 ```
 
 The benefit of this last solution is that it works for code you don't have control over. An alternative solution is to use the [griffe-autodocstringstyle extension](https://mkdocstrings.github.io/griffe/extensions/official/autodocstringstyle/) (sponsors only), which automatically assigns the `auto` style to all objects coming from sources found in a virtual environment.

--- a/docs/reference/api/docstrings/parsers.md
+++ b/docs/reference/api/docstrings/parsers.md
@@ -10,6 +10,8 @@
 
 ::: griffe.parse_numpy
 
+::: griffe.parse_rest
+
 ::: griffe.parse_sphinx
 
 ::: griffe.DocstringStyle

--- a/docs/reference/docstrings.md
+++ b/docs/reference/docstrings.md
@@ -7,6 +7,7 @@ The available parsers are:
 - `google`, to parse Google-style docstrings, see [Napoleon's documentation][napoleon]
 - `numpy`, to parse Numpydoc docstrings, see [Numpydoc's documentation][numpydoc]
 - `sphinx`, to parse Sphinx-style docstrings, see [Sphinx's documentation][sphinx]
+- `rest`, to parse ReST-style docstrings, see
 - `auto` (sponsors only), to automatically detect the docstring style, see [Auto-style](#auto-style)
 
 Most of the time, the syntax specified in the aforementioned docs is supported. In some cases, the original syntax is not supported, or is supported but with subtle differences. We will try to document these differences in the following sections.
@@ -1425,57 +1426,57 @@ For non-Insiders versions, `default` is returned if specified, else the first pa
 
 ### Sections
 
-Section          | Google | Numpy | Sphinx
----------------- | ------ | ----- | ------
-Attributes       | ✅     | ✅    | ✅
-Functions        | ✅     | ✅    | ❌
-Methods          | ✅     | ✅    | ❌
-Classes          | ✅     | ✅    | ❌
-Modules          | ✅     | ✅    | ❌
-Examples         | ✅     | ✅    | [❌][issue-section-sphinx-examples]
-Parameters       | ✅     | ✅    | ✅
-Other Parameters | ✅     | ✅    | [❌][issue-section-sphinx-other-parameters]
-Raises           | ✅     | ✅    | ✅
-Warns            | ✅     | ✅    | [❌][issue-section-sphinx-warns]
-Yields           | ✅     | ✅    | [❌][issue-section-sphinx-yields]
-Receives         | ✅     | ✅    | [❌][issue-section-sphinx-receives]
-Returns          | ✅     | ✅    | ✅
+Section          | Google | Numpy | Sphinx | ReST
+---------------- | ------ | ----- | ------ | ----
+Attributes       | ✅     | ✅    | ✅    |
+Functions        | ✅     | ✅    | ❌    |
+Methods          | ✅     | ✅    | ❌    |
+Classes          | ✅     | ✅    | ❌    |
+Modules          | ✅     | ✅    | ❌    |
+Examples         | ✅     | ✅    | [❌][issue-section-sphinx-examples]    |
+Parameters       | ✅     | ✅    | ✅    |
+Other Parameters | ✅     | ✅    | [❌][issue-section-sphinx-other-parameters]    |
+Raises           | ✅     | ✅    | ✅    |
+Warns            | ✅     | ✅    | [❌][issue-section-sphinx-warns]    |
+Yields           | ✅     | ✅    | [❌][issue-section-sphinx-yields]    |
+Receives         | ✅     | ✅    | [❌][issue-section-sphinx-receives]    |
+Returns          | ✅     | ✅    | ✅    |
 
 ### Getting annotations/defaults from parent
 
-Section          | Google | Numpy | Sphinx
----------------- | ------ | ----- | ------
-Attributes       | ✅     | ✅    | [❌][issue-parent-sphinx-attributes]
-Functions        | /      | /     | /
-Methods          | /      | /     | /
-Classes          | /      | /     | /
-Modules          | /      | /     | /
-Examples         | /      | /     | /
-Parameters       | ✅     | ✅    | ✅
-Other Parameters | ✅     | ✅    | [❌][issue-parent-sphinx-other-parameters]
-Raises           | /      | /     | /
-Warns            | /      | /     | /
-Yields           | ✅     | ✅    | [❌][issue-parent-sphinx-yields]
-Receives         | ✅     | ✅    | [❌][issue-parent-sphinx-receives]
-Returns          | ✅     | ✅    | ✅
+Section          | Google | Numpy | Sphinx | ReST
+---------------- | ------ | ----- | ------ | ----
+Attributes       | ✅     | ✅    | [❌][issue-parent-sphinx-attributes]    |
+Functions        | /      | /     | /    |
+Methods          | /      | /     | /    |
+Classes          | /      | /     | /    |
+Modules          | /      | /     | /    |
+Examples         | /      | /     | /    |
+Parameters       | ✅     | ✅    | ✅   |
+Other Parameters | ✅     | ✅    | [❌][issue-parent-sphinx-other-parameters]    |
+Raises           | /      | /     | /    |
+Warns            | /      | /     | /    |
+Yields           | ✅     | ✅    | [❌][issue-parent-sphinx-yields]    |
+Receives         | ✅     | ✅    | [❌][issue-parent-sphinx-receives]    |
+Returns          | ✅     | ✅    | ✅    |
 
 ### Cross-references for annotations in docstrings
 
-Section          | Google | Numpy | Sphinx
----------------- | ------ | ----- | ------
-Attributes       | ✅     | ✅    | [❌][issue-xref-sphinx-attributes]
-Functions        | [❌][issue-xref-google-func-cls] | [❌][issue-xref-numpy-func-cls] | /
-Methods          | [❌][issue-xref-google-func-cls] | [❌][issue-xref-numpy-func-cls] | /
-Classes          | [❌][issue-xref-google-func-cls] | [❌][issue-xref-numpy-func-cls] | /
-Modules          | /      | /     | /
-Examples         | /      | /     | /
-Parameters       | ✅     | ✅    | [❌][issue-xref-sphinx-parameters]
-Other Parameters | ✅     | ✅    | [❌][issue-xref-sphinx-other-parameters]
-Raises           | ✅     | ✅    | [❌][issue-xref-sphinx-raises]
-Warns            | ✅     | ✅    | [❌][issue-xref-sphinx-warns]
-Yields           | ✅     | ✅    | [❌][issue-xref-sphinx-yields]
-Receives         | ✅     | ✅    | [❌][issue-xref-sphinx-receives]
-Returns          | ✅     | ✅    | [❌][issue-xref-sphinx-returns]
+Section          | Google | Numpy | Sphinx | ReST
+---------------- | ------ | ----- | ------ |
+Attributes       | ✅     | ✅    | [❌][issue-xref-sphinx-attributes]    |
+Functions        | [❌][issue-xref-google-func-cls] | [❌][issue-xref-numpy-func-cls] | /    |
+Methods          | [❌][issue-xref-google-func-cls] | [❌][issue-xref-numpy-func-cls] | /    |
+Classes          | [❌][issue-xref-google-func-cls] | [❌][issue-xref-numpy-func-cls] | /    |
+Modules          | /      | /     | /    |
+Examples         | /      | /     | /    |
+Parameters       | ✅     | ✅    | [❌][issue-xref-sphinx-parameters]    |
+Other Parameters | ✅     | ✅    | [❌][issue-xref-sphinx-other-parameters]    |
+Raises           | ✅     | ✅    | [❌][issue-xref-sphinx-raises]    |
+Warns            | ✅     | ✅    | [❌][issue-xref-sphinx-warns]    |
+Yields           | ✅     | ✅    | [❌][issue-xref-sphinx-yields]    |
+Receives         | ✅     | ✅    | [❌][issue-xref-sphinx-receives]    |
+Returns          | ✅     | ✅    | [❌][issue-xref-sphinx-returns]    |
 
 [doctest]: https://docs.python.org/3/library/doctest.html#module-doctest
 [doctest flags]: https://docs.python.org/3/library/doctest.html#option-flags

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "pdm.backend"
 [project]
 name = "griffe"
 description = "Signatures for entire Python programs. Extract the structure, the frame, the skeleton of your project, to generate API documentation or find breaking changes in your API."
-authors = [{name = "Timothée Mazzucotelli", email = "dev@pawamoy.fr"}]
+authors = [{ name = "Timothée Mazzucotelli", email = "dev@pawamoy.fr" }]
 license = "ISC"
 license-files = ["LICENSE"]
 readme = "README.md"
@@ -37,7 +37,7 @@ classifiers = [
     "Typing :: Typed",
 ]
 dependencies = [
-    "colorama>=0.4", "python-cdd>=0.0.99rc46"
+    "colorama>=0.4", "cdd-python@git+https://github.com/offscale/cdd-python"
 ]
 
 [project.urls]
@@ -77,7 +77,7 @@ source-includes = [
 # Depending on the installation tool, they will be accessible to users.
 # pipx supports it, uv does not yet, see https://github.com/astral-sh/uv/issues/4731.
 data = [
-    {path = "share/**/*", relative-to = "."},
+    { path = "share/**/*", relative-to = "." },
 ]
 
 [dependency-groups]
@@ -101,7 +101,7 @@ ci = [
     "types-markdown>=3.6",
     "types-pyyaml>=6.0",
 ]
- docs = [
+docs = [
     "code2flow>=2.5",
     "griffe-inherited-docstrings>=1.0",
     "markdown-callouts>=0.4",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ classifiers = [
     "Typing :: Typed",
 ]
 dependencies = [
-    "colorama>=0.4",
+    "colorama>=0.4", "python-cdd>=0.0.99rc46"
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ classifiers = [
     "Typing :: Typed",
 ]
 dependencies = [
-    "colorama>=0.4", "cdd-python@git+https://github.com/offscale/cdd-python"
+    "colorama>=0.4", "cdd@git+https://github.com/offscale/cdd-python"
 ]
 
 [project.urls]

--- a/src/_griffe/docstrings/parsers.py
+++ b/src/_griffe/docstrings/parsers.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Any, Callable, Literal
 from _griffe.docstrings.google import parse_google
 from _griffe.docstrings.models import DocstringSection, DocstringSectionText
 from _griffe.docstrings.numpy import parse_numpy
+from _griffe.docstrings.rest import parse_rest
 from _griffe.docstrings.sphinx import parse_sphinx
 from _griffe.enumerations import Parser
 
@@ -20,7 +21,7 @@ if TYPE_CHECKING:
 # plain markup docstrings, which could lead to false positives. Same for Numpy
 # sections, whose syntax is regular rST markup, and which can therefore appear
 # in plain markup docstrings too, even more often than Google sections.
-_default_style_order = [Parser.sphinx, Parser.google, Parser.numpy]
+_default_style_order = [Parser.sphinx, Parser.google, Parser.numpy, Parser.rest]
 
 
 DocstringStyle = Literal["google", "numpy", "sphinx", "rest", "auto"]
@@ -115,6 +116,7 @@ def parse_auto(
 parsers: dict[Parser, Callable[[Docstring], list[DocstringSection]]] = {
     Parser.auto: parse_auto,
     Parser.google: parse_google,
+    Parser.rest: parse_rest,
     Parser.sphinx: parse_sphinx,
     Parser.numpy: parse_numpy,
 }

--- a/src/_griffe/docstrings/parsers.py
+++ b/src/_griffe/docstrings/parsers.py
@@ -23,7 +23,7 @@ if TYPE_CHECKING:
 _default_style_order = [Parser.sphinx, Parser.google, Parser.numpy]
 
 
-DocstringStyle = Literal["google", "numpy", "sphinx", "auto"]
+DocstringStyle = Literal["google", "numpy", "sphinx", "rest", "auto"]
 """The supported docstring styles (literal values of the Parser enumeration)."""
 DocstringDetectionMethod = Literal["heuristics", "max_sections"]
 """The supported methods to infer docstring styles."""

--- a/src/_griffe/docstrings/rest.py
+++ b/src/_griffe/docstrings/rest.py
@@ -1,0 +1,62 @@
+# This module defines functions to parse ReST-style docstrings into structured data.
+
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from _griffe.docstrings.models import (
+    DocstringSection
+)
+from _griffe.enumerations import DocstringSectionKind
+
+if TYPE_CHECKING:
+    from typing import Any
+
+    from _griffe.models import Docstring
+
+
+_section_kind = {
+    "deprecated": DocstringSectionKind.deprecated,
+    "parameters": DocstringSectionKind.parameters,
+    "other parameters": DocstringSectionKind.other_parameters,
+    "returns": DocstringSectionKind.returns,
+    "yields": DocstringSectionKind.yields,
+    "receives": DocstringSectionKind.receives,
+    "raises": DocstringSectionKind.raises,
+    "warns": DocstringSectionKind.warns,
+    "examples": DocstringSectionKind.examples,
+    "attributes": DocstringSectionKind.attributes,
+    "functions": DocstringSectionKind.functions,
+    "methods": DocstringSectionKind.functions,
+    "classes": DocstringSectionKind.classes,
+    "modules": DocstringSectionKind.modules,
+}
+
+
+def parse_rest(
+    docstring: Docstring,
+    *,
+    ignore_init_summary: bool = False,
+    trim_doctest_flags: bool = True,
+    warn_unknown_params: bool = True,
+    warnings: bool = True,
+    **options: Any,
+) -> list[DocstringSection]:
+    """Parse a ReST-style docstring.
+
+    This function iterates on lines of a docstring to build sections.
+    It then returns this list of sections.
+
+    Parameters:
+        docstring: The docstring to parse.
+        ignore_init_summary: Whether to ignore the summary in `__init__` methods' docstrings.
+        trim_doctest_flags: Whether to remove doctest flags from Python example blocks.
+        warn_unknown_params: Warn about documented parameters not appearing in the signature.
+        warnings: Whether to log warnings at all.
+        **options: Additional parsing options.
+
+    Returns:
+        A list of docstring sections.
+    """
+    raise NotImplementedError()

--- a/src/_griffe/docstrings/rest.py
+++ b/src/_griffe/docstrings/rest.py
@@ -9,8 +9,13 @@ import cdd.docstring.parse
 import cdd.shared.types
 
 from _griffe.docstrings.models import (
-    DocstringSection, DocstringSectionText, DocstringSectionReturns, DocstringNamedElement, DocstringReturn,
-    DocstringSectionParameters, DocstringParameter
+    DocstringSection,
+    DocstringSectionText,
+    DocstringSectionReturns,
+    DocstringNamedElement,
+    DocstringReturn,
+    DocstringSectionParameters,
+    DocstringParameter,
 )
 from _griffe.enumerations import DocstringSectionKind
 
@@ -37,18 +42,40 @@ _section_kind = {
     "modules": DocstringSectionKind.modules,
 }
 
-def ir_param_to_griffe_param(ir_param: OrderedDict[str, cdd.shared.types.ParamVal]) -> list[DocstringNamedElement]:
-    return [DocstringNamedElement(name=name, description=param["doc"],
-                                  annotation=param["typ"], value=param["default"])
-            for name, param in ir_param.items()]
+
+def ir_param_to_griffe_param(
+    ir_param: OrderedDict[str, cdd.shared.types.ParamVal],
+) -> list[DocstringNamedElement]:
+    """
+    Convert an `OrderedDict` of cdd-python's `ParamVal` to a `list` of griffe's `DocstringNamedElement`
+    """
+    return [
+        DocstringNamedElement(
+            name=name,
+            description=param["doc"],
+            annotation=param["typ"],
+            value=param["default"],
+        )
+        for name, param in ir_param.items()
+    ]
+
 
 def ir_to_griffe(ir: cdd.shared.types.IntermediateRepr) -> list[DocstringSection]:
+    """
+    Convert cdd-python's IR to a list of griffe's `DocstringSection`s
+    """
     sections: list[DocstringSection] = [
         DocstringSectionText(ir["doc"]),
-        DocstringSectionParameters(list(map(DocstringParameter, ir_param_to_griffe_param(ir["params"]))))
+        DocstringSectionParameters(
+            list(map(DocstringParameter, ir_param_to_griffe_param(ir["params"])))
+        ),
     ]
     if ir["returns"]:
-        sections.append(DocstringSectionReturns([next(map(DocstringReturn, ir_param_to_griffe_param(ir["returns"])))]))
+        sections.append(
+            DocstringSectionReturns(
+                [next(map(DocstringReturn, ir_param_to_griffe_param(ir["returns"])))]
+            )
+        )
     return sections
 
 
@@ -77,5 +104,10 @@ def parse_rest(
     Returns:
         A list of docstring sections.
     """
-    ir: cdd.shared.types.IntermediateRepr = cdd.docstring.parse.docstring(docstring.value)
+    ir: cdd.shared.types.IntermediateRepr = cdd.docstring.parse.docstring(
+        docstring.value
+    )
     return ir_to_griffe(ir)
+
+
+__all__ = ["parse_rest"]

--- a/src/_griffe/docstrings/rest.py
+++ b/src/_griffe/docstrings/rest.py
@@ -54,7 +54,7 @@ def ir_param_to_griffe_param(
             name=name,
             description=param["doc"],
             annotation=param["typ"],
-            value=param["default"],
+            value=param["default"] if param.get("default") else None,
         )
         for name, param in ir_param.items()
     ]

--- a/src/_griffe/enumerations.py
+++ b/src/_griffe/enumerations.py
@@ -142,6 +142,8 @@ class Parser(str, Enum):
     """
     google = "google"
     """Google-style docstrings parser."""
+    rest = "rest"
+    """ReST-style docstrings parser."""
     sphinx = "sphinx"
     """Sphinx-style docstrings parser."""
     numpy = "numpy"

--- a/src/griffe/__init__.py
+++ b/src/griffe/__init__.py
@@ -99,6 +99,7 @@ Docstring parsers:
 - [`griffe.parse_auto`][]: Parse a docstring by automatically detecting the style it uses.
 - [`griffe.parse_google`][]: Parse a Google-style docstring.
 - [`griffe.parse_numpy`][]: Parse a Numpydoc-style docstring.
+- [`griffe.parse_rest`][]: Parse a ReST-style docstring.
 - [`griffe.parse_sphinx`][]: Parse a Sphinx-style docstring.
 
 ## Exceptions


### PR DESCRIPTION
WiP, when ready will close #397 

Related: #132

EDIT: Confirmed it works, I just generated the docs—in [`c2ad18f`](https://github.com/offscale/offscale-www/commit/c2ad18f)—for my [cdd-python](https://github.com/offscale/cdd-python) @ https://offscale.io/cdd-python/