### PR TITLE
fix: Do not ignore stderr in case there is a problem in a git call.

### DIFF
--- a/src/griffe/_internal/git.py
+++ b/src/griffe/_internal/git.py
@@ -36,7 +36,7 @@ def _normalize(value: str) -> str:
 def _git(*args: str, check: bool = True) -> str:
     process = subprocess.run(["git", *args], check=False, text=True, capture_output=True)
     if check and process.returncode != 0:
-        raise GitError(process.stdout.strip())
+        raise GitError(process.stdout.strip() + "\n" + process.stderr.strip())
     return process.stdout.strip()
 
 


### PR DESCRIPTION
Previously griffe was only printing the output of stdout in case there was a problem in a git call. This commit implements printing the stderr along with stdout.

Issue-415: https://github.com/mkdocstrings/griffe/issues/415

### For reviewers
<!-- Help reviewers by letting them know whether AI was used to create this PR. -->

- [x ] I did not use AI
- [ ] I used AI and thorougly reviewed every code/docs change

### Description of the change
<!-- Quick sentence for small changes, longer description for more impacting changes. -->
Append stderr to stdout in case git call fails.
