### PR TITLE
Fix ObjectNode.module_path

### DIFF
--- a/src/griffe/_internal/agents/nodes/runtime.py
+++ b/src/griffe/_internal/agents/nodes/runtime.py
@@ -117,10 +117,25 @@ class ObjectNode:
             except AttributeError:
                 return getattr(module, "__name__", None)
         else:
+            # Some libraries mistakenly set `__module__` to a module object instead of a string.
+            # Handle this case specifically, but do not cast any other object to a string.
             if isinstance(module, ModuleType):
+                logger.debug(
+                    "Object %s has its `__module__` attribute set to a module object: "
+                    "it must be a string instead (the module fully qualified name). "
+                    "Please report to the maintainers of this library.",
+                    self.path,
+                )
                 return getattr(module, "__qualname__", getattr(module, "__name__", None))
             if isinstance(module, str):
                 return module
+            logger.debug(
+                "Object %s has its `__module__` attribute set to a %s object: "
+                "it must be a string instead (the module fully qualified name). "
+                "Please report to the maintainers of this library.",
+                self.path,
+                getattr(type(module), "__name__", str(type(module))),
+            )
             return None
 
     @property


### PR DESCRIPTION
### For reviewers
<!-- Help reviewers by letting them know whether AI was used to create this PR. -->

- [X] I did not use AI
- [ ] I used AI and thorougly reviewed every code/docs change

### Description of the change
<!-- Quick sentence for small changes, longer description for more impacting changes. -->

`module_path` property returns ModuleType in some scenarios where `self.obj.__module__`  has a `ModuleType` value, this causes bugs because other functions assume it returns a string with the name of the module.

It is not clear to me why `self.obj.__module__`  is `ModuleType`  sometimes and `str` other times.

```
  File ".../.venv/lib/python3.11/site-packages/griffe/_internal/agents/nodes/runtime.py", line 38, in _same_components
    return [cpn.lstrip("_") for cpn in a.split(".")] == [cpn.lstrip("_") for cpn in b.split(".")]

AttributeError: module 'PathApp' has no attribute 'split'

```
