### PR TITLE
feat: Prefer stub over target object if not the same kind

### DIFF
--- a/src/griffe/_internal/merger.py
+++ b/src/griffe/_internal/merger.py
@@ -88,6 +88,10 @@ def _merge_stubs_members(obj: Module | Class, stubs: Module | Class) -> None:
                 if obj_member.kind is not stub_member.kind:
                     # If the stub and the target are not of the same kind, prefer the
                     # stub over the target.
+                    logger.debug(
+                        "Source object `%s` will be overwritten by stub object.",
+                        obj_member.path,
+                    )
                     obj.set_member(stub_member.name, stub_member)
                 elif obj_member.is_module:
                     _merge_module_stubs(obj_member, stub_member)  # type: ignore[arg-type]


### PR DESCRIPTION
### For reviewers
<!-- Help reviewers by letting them know whether AI was used to create this PR. -->

- [x] I did not use AI
- [ ] I used AI and thorougly reviewed every code/docs change

### Description of the change
<!-- Quick sentence for small changes, longer description for more impacting changes. -->
This update changes the behavior of handling stub packages when encountering a target object and stub that are of a different kind. `griffe` no longer skips the stub in this case, and instead prefers the stub over the target.

Successfully tested on my current documentation project wherein `griffe` was seeing a `class` object as a `module-attribute`, and with the change, is successfully rendering it as a `class` with the expected docstring from a `.pyi` file.

Both `make check` and `make test` are not working for me. If desired, I can provide the failure details. I'm including this to note that neither were run before submitting this PR.

### Relevant resources
<!-- Link to any relevant GitHub issue, PR or discussion, section in online docs, etc. -->

- `mkdocstrings` discussion 803: https://github.com/mkdocstrings/mkdocstrings/discussions/803
