### PR TITLE
fix: Make type aliases available at runtime

### DIFF
--- a/src/griffe/_internal/models.py
+++ b/src/griffe/_internal/models.py
@@ -2717,7 +2717,7 @@ class TypeAlias(Object):
             value: The type alias value.
             **kwargs: See [`griffe.Object`][].
         """
-        super().__init__(*args, **kwargs, runtime=False)
+        super().__init__(*args, **kwargs)
         self.value: str | Expr | None = value
         """The type alias value."""
 


### PR DESCRIPTION
### For reviewers
<!-- Help reviewers by letting them know whether AI was used to create this PR. -->

- [x] I did not use AI
- [ ] I used AI and thorougly reviewed every code/docs change

### Description of the change

Given a module like this:

```python
# __init__.py

from ._typing import *
```

```python
# _typing.py

__all__ = ("TA1", "TA2")

type TA1 = list[int]
TA2 = list[int]
```

One can access `my_module.TA1` at runtime (Python 3.12):

```
>>> import my_module
>>> my_module.TA1.__value__
list[int]
```

So `TypeAlias`s should be marked as being available at runtime.

### Relevant resources

- https://github.com/mkdocstrings/griffe/discussions/425

