### PR TITLE
ci: Fix docs building on TAOS

### DIFF
--- a/docs/guide/contributors/architecture.md
+++ b/docs/guide/contributors/architecture.md
@@ -70,7 +70,7 @@ def exptree(path):
         print(f"{index}. {descriptions.get(str(node), '')}\n")
         if node.is_dir() and node in recurse:
             print('    ```python exec="1" session="filetree" idprefix=""')
-            print(f'    exptree("{node}")')
+            print(f'    exptree("{node.as_posix()}")')
             print("    ```\n")
 ```
 


### PR DESCRIPTION
### For reviewers
<!-- Help reviewers by letting them know whether AI was used to create this PR. -->

- [x] I did not use AI
- [ ] I used AI and thoroughly reviewed every code/docs change

### Description of the change
<!-- Quick sentence for small changes, longer description for more impacting changes. -->

The annoying operating system is annoying. We try to circumvent these annoyances.

### Relevant resources
<!-- Link to any relevant GitHub issue, PR or discussion, section in online docs, etc. -->

```
WARNING -  markdown_exec: Execution of python code block exited with errors

  Code block is:

    exptree("config\vscode")

  Output is:

    Traceback (most recent call last):
      File "D:\a\griffe\griffe\.venv\lib\site-packages\markdown_exec\_internal\formatters\python.py", line 71, in _run_python
        exec_python(code, code_block_id, exec_globals)
      File "D:\a\griffe\griffe\.venv\lib\site-packages\markdown_exec\_internal\formatters\_exec_python.py", line 8, in exec_python
        exec(compiled, exec_globals)  # noqa: S102
      File "<code block: session filetree; n7>", line 1, in <module>
        exptree("config\vscode")
      File "<code block: session filetree; n1>", line 35, in exptree
        for node in Path(path).iterdir():
      File "C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\pathlib.py", line 1017, in iterdir
        for name in self._accessor.listdir(self):
    OSError: [WinError 123] The filename, directory name, or volume label syntax is incorrect: 'config\x0bscode'
```
