### PR TITLE
feat: Support merging overload annotations into implementation

### DIFF
--- a/tests/test_merger.py
+++ b/tests/test_merger.py
@@ -73,3 +73,25 @@ def test_merge_attribute_values() -> None:
         },
     ) as pkg:
         assert str(pkg["__all__"].value) == "['hello']"
+
+
+def test_merge_overload_annotations() -> None:
+    """Assert that overload annotations are merged correctly."""
+    with temporary_visited_package(
+        "package",
+        {
+            "mod.py": "def func(x): ...",
+            "mod.pyi": """
+                from typing import overload
+
+                @overload
+                def func(x: int) -> int: ...
+
+                @overload
+                def func(x: float) -> float: ...
+                """,
+        },
+    ) as pkg:
+        func = pkg["mod.func"]
+        assert str(func.parameters["x"].annotation) == "int | float"
+        assert str(func.returns) == "int | float"


### PR DESCRIPTION
### For reviewers

- [x] I did not use AI
- [ ] I used AI and thoroughly reviewed every code/docs change

### Description of the change

Users sometimes declare overloads (in .pyi files or not) with annotations, and leave their implementation without any annotations. This change automatically merges annotations from overloads for each parameter into the implementation parameter annotations.

### Relevant resources

- #442
