### PR TITLE
fix: Suppress ty type errors triggered on Linux (Self-type / module-path conflicts)

### DIFF
--- a/packages/griffelib/src/griffe/_internal/loader.py
+++ b/packages/griffelib/src/griffe/_internal/loader.py
@@ -531,7 +531,7 @@ class GriffeLoader:
         Returns:
             Some statistics.
         """
-        stats = Stats(self)
+        stats = Stats(self)  # ty:ignore[invalid-argument-type]
         stats.time_spent_visiting = self._time_stats["time_spent_visiting"]
         stats.time_spent_inspecting = self._time_stats["time_spent_inspecting"]
         return stats

--- a/packages/griffelib/src/griffe/_internal/models.py
+++ b/packages/griffelib/src/griffe/_internal/models.py
@@ -180,7 +180,7 @@ class Docstring:
         Returns:
             The parsed docstring as a list of sections.
         """
-        return parse(self, parser or self.parser, **(options or self.parser_options))
+        return parse(self, parser or self.parser, **(options or self.parser_options))  # ty:ignore[invalid-argument-type]
 
     def as_dict(
         self,
@@ -2152,7 +2152,7 @@ class Alias(ObjectAliasMixin):
         try:
             resolved = self.modules_collection.get_member(self.target_path)
         except KeyError as error:
-            raise AliasResolutionError(self) from error
+            raise AliasResolutionError(self) from error  # ty:ignore[invalid-argument-type]
         if resolved is self:
             raise CyclicAliasError([self.target_path])
         if resolved.is_alias and not resolved.resolved:
@@ -2404,7 +2404,7 @@ class Class(Object):
         do not use when producing Griffe trees!
         """
         try:
-            return self.all_members["__init__"].parameters  # ty:ignore[unresolved-attribute]
+            return self.all_members["__init__"].parameters  # ty:ignore[unresolved-attribute,invalid-return-type]
         except KeyError:
             return Parameters()
 


### PR DESCRIPTION
## Summary

- `Stats.__init__`, `Docstring.parse`, `AliasResolutionError.__init__` (invalid-argument-type) and `Class.parameters` (invalid-return-type) produce ty errors on Linux CI but not on macOS.
- The `invalid-return-type` case has a particularly clear signal: ty sees two different qualified paths for the same class — `packages.griffelib.src.griffe._internal.models.Parameters` (source tree) vs `griffe._internal.models.Parameters` (installed package) — and treats them as incompatible types.
- Suppressing with `ty:ignore` for now until `ty` handles this case correctly.

## Test plan

- [ ] CI passes on all platforms after this change.

💞 Generated with the [darling work system](https://github.com/johnslavik/darling)