### PR TITLE
feat: Add logging format for azure devops

### DIFF
--- a/docs/guide/users/checking.md
+++ b/docs/guide/users/checking.md
@@ -744,6 +744,17 @@ When running `griffe check` in CI, you can enable GitHub's annotations thanks to
 ::warning file=src/griffe/finder.py,line=77,title=NamespacePackage.path::Attribute value was changed: `path` -> unset
 ```
 
+[](){#format-azdo}
+
+### Azure DevOps / Azure Pipelines
+
+- **CLI**: `-f azdo`
+- **API**: `check(..., style="azdo")` / `check(..., style=ExplanationStyle.AZURE_DEVOPS)`
+
+Similar to the github workflow syntax, griff also is capable of using the task logging command syntax used by Azure Pipelines as part of the Azure DevOps Services.
+
+When running `griffe check` in CI, warnings are displayed in the warnings panel of your pipeline.
+
 ## Next steps
 
 If you are using a third-party library to mark objects as public, or if you follow conventions different than the one Griffe understands, you might get false-positives, or breaking changes could go undetected. In that case, you might be interested in [extending](extending.md) how Griffe loads API data to support these third-party libraries or other conventions.

--- a/docs/guide/users/checking.md
+++ b/docs/guide/users/checking.md
@@ -115,6 +115,30 @@ jobs:
 
 The last step will fail the workflow if any breaking change is found.
 
+### Azure Pipelines {#ci-azdo}
+
+Here is a quick example on how to use Griffe in an Azure Pipeline as it can be instructed to generated [task logging commands](https://learn.microsoft.com/en-us/azure/devops/pipelines/scripts/logging-commands?view=azure-devops&tabs=bash#task-commands):
+
+```yaml
+jobs:
+  - name: check-api
+    pool:
+      vmImage: 'ubuntu-latest'
+    steps:
+      - checkout: self 
+        fetchDepth: 0  # We the need the full Git history.
+      - task: CmdLine@2
+        inputs:
+          script: pip install --user uvx
+      - task: CmdLine@2
+        inputs:
+          # The following command will compare current changes to latest tag.
+          script: | 
+            uvx griffe check --search src --format azdo your_package_name
+            
+```
+The last step will fail the workflow if any breaking change is found.
+
 ## Detected breakages
 
 In this section, we will describe the breakages that Griffe detects, giving some code examples and hints on how to properly communicate breakages with deprecation messages before actually releasing them.

--- a/docs/guide/users/checking.md
+++ b/docs/guide/users/checking.md
@@ -129,12 +129,12 @@ jobs:
         fetchDepth: 0  # We the need the full Git history.
       - task: CmdLine@2
         inputs:
-          script: pip install --user uvx
+          script: pip install --user griffe
       - task: CmdLine@2
         inputs:
           # The following command will compare current changes to latest tag.
           script: | 
-            uvx griffe check --search src --format azdo your_package_name
+            griffe check --search src --format azdo your_package_name
             
 ```
 

--- a/docs/guide/users/checking.md
+++ b/docs/guide/users/checking.md
@@ -751,7 +751,7 @@ When running `griffe check` in CI, you can enable GitHub's annotations thanks to
 - **CLI**: `-f azdo`
 - **API**: `check(..., style="azdo")` / `check(..., style=ExplanationStyle.AZURE_DEVOPS)`
 
-Similar to the github workflow syntax, griff also is capable of using the task logging command syntax used by Azure Pipelines as part of the Azure DevOps Services.
+Similarly to the GitHub workflow syntax, Griffe is also capable of using the task logging command syntax used by Azure Pipelines as part of the Azure DevOps Services.
 
 When running `griffe check` in CI, warnings are displayed in the warnings panel of your pipeline.
 

--- a/docs/guide/users/checking.md
+++ b/docs/guide/users/checking.md
@@ -117,25 +117,24 @@ The last step will fail the workflow if any breaking change is found.
 
 ### Azure Pipelines {#ci-azdo}
 
-Here is a quick example on how to use Griffe in an Azure Pipeline as it is capable to use Azure DevOps [task logging commands](https://learn.microsoft.com/en-us/azure/devops/pipelines/scripts/logging-commands?view=azure-devops&tabs=bash#task-commands) similar to github actions:
+Here is a quick example on how to use Griffe in an Azure Pipeline. Griffe can format its output using Azure DevOps [task logging commands](https://learn.microsoft.com/en-us/azure/devops/pipelines/scripts/logging-commands?view=azure-devops&tabs=bash#task-commands), similar to GitHub Actions messages:
 
 ```yaml
 jobs:
-  - name: check-api
-    pool:
-      vmImage: 'ubuntu-latest'
-    steps:
-      - checkout: self 
-        fetchDepth: 0  # We the need the full Git history.
-      - task: CmdLine@2
-        inputs:
-          script: pip install --user griffe
-      - task: CmdLine@2
-        inputs:
-          # The following command will compare current changes to latest tag.
-          script: | 
-            griffe check --search src --format azdo your_package_name
-            
+- name: check-api
+  pool:
+    vmImage: 'ubuntu-latest'
+  steps:
+  - checkout: self 
+    fetchDepth: 0  # We the need the full Git history.
+  - task: CmdLine@2
+    inputs:
+      script: pip install --user griffe
+  - task: CmdLine@2
+    inputs:
+      # The following command will compare current changes to latest tag.
+      script: | 
+        griffe check --search src --format azdo your_package_name
 ```
 
 The last step will fail the workflow if any breaking change is found.
@@ -752,7 +751,7 @@ When running `griffe check` in CI, you can enable GitHub's annotations thanks to
 - **CLI**: `-f azdo`
 - **API**: `check(..., style="azdo")` / `check(..., style=ExplanationStyle.AZURE_DEVOPS)`
 
-Similarly to the GitHub workflow syntax, Griffe is also capable of using the task logging command syntax used by Azure Pipelines as part of the Azure DevOps Services.
+Similarly to the GitHub workflow syntax, Griffe is capable of using the task logging command syntax used by Azure Pipelines as part of the Azure DevOps Services.
 
 When running `griffe check` in CI, warnings are displayed in the warnings panel of your pipeline.
 

--- a/docs/guide/users/checking.md
+++ b/docs/guide/users/checking.md
@@ -117,7 +117,7 @@ The last step will fail the workflow if any breaking change is found.
 
 ### Azure Pipelines {#ci-azdo}
 
-Here is a quick example on how to use Griffe in an Azure Pipeline as it can be instructed to generated [task logging commands](https://learn.microsoft.com/en-us/azure/devops/pipelines/scripts/logging-commands?view=azure-devops&tabs=bash#task-commands):
+Here is a quick example on how to use Griffe in an Azure Pipeline as it is capable to use Azure DevOps [task logging commands](https://learn.microsoft.com/en-us/azure/devops/pipelines/scripts/logging-commands?view=azure-devops&tabs=bash#task-commands) similar to github actions:
 
 ```yaml
 jobs:

--- a/docs/guide/users/checking.md
+++ b/docs/guide/users/checking.md
@@ -137,6 +137,7 @@ jobs:
             uvx griffe check --search src --format azdo your_package_name
             
 ```
+
 The last step will fail the workflow if any breaking change is found.
 
 ## Detected breakages

--- a/packages/griffelib/src/griffe/_internal/diff.py
+++ b/packages/griffelib/src/griffe/_internal/diff.py
@@ -280,6 +280,28 @@ class Breakage:
             return f"{explanation}: {change}"
         return explanation
 
+    def _explain_azdo(self) -> str:
+        location = f"sourcepath={self._location},linenumber={self._lineno}"
+        title = f"title={self._format_title(colors=False)}"
+        explanation = f"###vso[task.logissue type=warning;{location},{title}]{self.kind.value}"
+        old = self._format_old_value(colors=False)
+        if old and old != "unset":
+            old = f"`{old}`"
+        new = self._format_new_value(colors=False)
+        if new and new != "unset":
+            new = f"`{new}`"
+        if old and new:
+            change = f"{old} -> {new}"
+        elif old:
+            change = old
+        elif new:
+            change = new
+        else:
+            change = ""
+        if change:
+            return f"{explanation}: {change}"
+        return explanation
+
 
 class ParameterMovedBreakage(Breakage):
     """Specific breakage class for moved parameters."""

--- a/packages/griffelib/src/griffe/_internal/enumerations.py
+++ b/packages/griffelib/src/griffe/_internal/enumerations.py
@@ -117,6 +117,8 @@ class ExplanationStyle(str, Enum):
     """Explanations in Markdown, adapted to changelogs."""
     GITHUB = "github"
     """Explanation as GitHub workflow commands warnings, adapted to CI."""
+    AZURE_DEVOPS = "azdo"
+    """Explanations as Azure DevOps / Azure Pipelines logging commands."""
 
 
 class BreakageKind(str, Enum):


### PR DESCRIPTION
Azure DevOps is popular in enterprise contexts Adding the ability use logging commands in griffe during pipeline execution would be great.

This commit contains
- [X] A new enumeration value
- [X] A new _explain_azdo method
- [X] Update documentation
- [X] A manual test ran against latest tag.

### For reviewers
<!-- Help reviewers by letting them know whether AI was used to create this PR. -->

- [X] I did not use AI
- [ ] I used AI and thoroughly reviewed every code/docs change

This commit was purely made by humans

### Description of the change
<!-- Quick sentence for small changes, longer description for more impacting changes. -->

This change introduces a new logging output for griffe: Azure Pipelines Logging Commands to be used in Azure DevOps similar to Github workflows outputs.

### Relevant resources
<!-- Link to any relevant GitHub issue, PR or discussion, section in online docs, etc. -->

- https://learn.microsoft.com/en-us/azure/devops/pipelines/scripts/logging-commands?view=azure-devops&tabs=bash#task-commands