### PR TITLE
fix: Keep quotes on string members of unresolved Literal annotations

### DIFF
--- a/packages/griffelib/src/griffe/_internal/expressions.py
+++ b/packages/griffelib/src/griffe/_internal/expressions.py
@@ -1324,6 +1324,10 @@ def _build_subscript(
         if isinstance(left, (ExprAttribute, ExprName)) and left.canonical_path in {
             "typing.Literal",
             "typing_extensions.Literal",
+            # A `Literal` that could not be resolved (e.g. used without an
+            # import) keeps its bare name as canonical path. Its string members
+            # are literal strings, not forward references, so keep their quotes.
+            "Literal",
         }:
             literal_strings = True
         slice_expr = _build(

--- a/packages/griffelib/tests/test_expressions.py
+++ b/packages/griffelib/tests/test_expressions.py
@@ -61,6 +61,26 @@ def test_full_expressions(annotation: str) -> None:
         assert str(module["x"].annotation) == annotation
 
 
+@pytest.mark.parametrize(
+    "annotation",
+    [
+        "Literal['a-b']",
+        "Literal['a', 'b']",
+        "Literal['hello world']",
+    ],
+)
+def test_unresolved_literal_keeps_string_quotes(annotation: str) -> None:
+    """Assert string members of an unresolved `Literal` keep their quotes.
+
+    An unresolved `Literal` (used without an import) must still treat its
+    members as literal strings rather than forward references, otherwise
+    `Literal['a-b']` is mis-parsed as `Literal[a - b]`.
+    """
+    code = f"x: {annotation}"
+    with temporary_visited_module(code) as module:
+        assert str(module["x"].annotation) == annotation
+
+
 def test_resolving_full_names() -> None:
     """Assert expressions are correctly transformed to their fully-resolved form."""
     with temporary_visited_module(


### PR DESCRIPTION
### For reviewers
<!-- Help reviewers by letting them know whether AI was used to create this PR. -->

- [ ] I did not use AI
- [x] I used AI and thoroughly reviewed every code/docs change

### Description of the change

A `Literal[...]` whose name could not be resolved (for example used without `from typing import Literal`) keeps its bare name `"Literal"` as its canonical path. The guard in `_build_subscript` that enables `literal_strings` only matched the resolved spellings `typing.Literal` / `typing_extensions.Literal`, so for an unresolved `Literal` the string members were treated as forward references and re-parsed:

```python
# unresolved Literal (no import)
x: Literal['a-b']      # -> Literal[a - b]   (parsed as a subtraction!)
y: Literal['a', 'b']   # -> Literal[a, b]    (names, not strings)
```

A resolved `Literal` keeps the quotes (`Literal['a-b']`), and value-position strings always keep theirs, so the two paths were inconsistent.

This adds the bare `"Literal"` spelling to that set. A genuinely user-defined `Literal` resolves to a dotted path (e.g. `mod.Literal`), so it is not over-matched, and forward references elsewhere (e.g. `list['Foo']` → `list[Foo]`) are unaffected.

Verified:
- `Literal['a-b']`, `Literal['a', 'b']`, `Literal['hello world']` (unresolved) now round-trip with quotes intact.
- Regression cases hold: imported `Literal`, `typing.Literal[...]`, aliased import, int literals, and `list['Foo']` still resolving its forward reference.
- Added a parametrized regression test in `tests/test_expressions.py` (it fails before the change, passes after). `test_expressions.py`: 146 passed. `ruff check` clean (zero new warnings).

### Relevant resources

-
-
-
