### PR TITLE
fix: render dict `**`-unpacking as `**value` instead of `None: value`

### DIFF
--- a/packages/griffelib/src/griffe/_internal/expressions.py
+++ b/packages/griffelib/src/griffe/_internal/expressions.py
@@ -452,7 +452,7 @@ class ExprDict(Expr):
     def iterate(self, *, flat: bool = True) -> Iterator[str | Expr]:
         yield "{"
         yield from _join(
-            (("None" if key is None else key, ": ", value) for key, value in zip(self.keys, self.values, strict=False)),
+            (("**", value) if key is None else (key, ": ", value) for key, value in zip(self.keys, self.values, strict=False)),
             ", ",
             flat=flat,
         )

--- a/packages/griffelib/tests/test_expressions.py
+++ b/packages/griffelib/tests/test_expressions.py
@@ -241,3 +241,22 @@ def test_render_dict_comprehension() -> None:
         """,
     ) as module:
         assert str(module["d"].value) == "{k: v for k, v in items if k}"
+
+
+def test_render_dict_with_unpacking() -> None:
+    """Assert dictionaries using `**`-unpacking are rendered correctly.
+
+    The AST marks an unpacked value with a `None` key, which must render as
+    `**value` rather than as a literal `None` key. A genuine `None` literal key
+    (an `ast.Constant`, not the AST's unpacking marker) must be preserved.
+    """
+    with temporary_visited_module(
+        """
+        a = {**base, "x": 1}
+        b = {**d1, **d2}
+        c = {None: 1, "y": 2}
+        """,
+    ) as module:
+        assert str(module["a"].value) == "{**base, 'x': 1}"
+        assert str(module["b"].value) == "{**d1, **d2}"
+        assert str(module["c"].value) == "{None: 1, 'y': 2}"


### PR DESCRIPTION
<!-- Help reviewers by letting them know whether AI was used to create this PR. -->

- [ ] I did not use AI
- [x] I used AI and thoroughly reviewed every code/docs change

## Description

`ExprDict.iterate` renders the `None` key that the AST uses to mark a `**`-unpacked value as a literal `None: value`, producing invalid (and semantically wrong) Python:

```python
def f(a={**base, "x": 1}): ...   # default renders as  {None: base, 'x': 1}
def g(b={**d1, **d2}): ...       # default renders as  {None: d1, None: d2}
```

`_build_dict` faithfully preserves the AST's `None`-key unpacking marker, but `iterate` then renders it with the literal text `"None"`. This affects any rendered signature/default/annotation containing a dict with `**`-unpacking.

The fix renders entries whose key is the unpacking marker as `**value` (no `key: ` part):

```python
def f(a={**base, "x": 1}): ...   # now renders as  {**base, 'x': 1}
def g(b={**d1, **d2}): ...       # now renders as  {**d1, **d2}
```

A genuine `None` **literal** key is an `ast.Constant`, not the AST's unpacking marker, so it is left untouched (`{None: 1, "y": 2}` still renders as `{None: 1, 'y': 2}`).

## Verification

- Added `test_render_dict_with_unpacking` covering `**`-spread, multiple spreads, and the literal-`None`-key case.
- Round-trip oracle: every rendered form now re-parses AST-equal to its source.
- Full `griffelib` suite passes with no new failures (the unrelated `test_finder.py::test_pth_file_handling*` and `test_api`/`test_git` failures are pre-existing on this environment, identical with the change stashed).

---

This pull request was prepared with the assistance of AI, under my direction and review.
