### PR TITLE
docs: Fix google-style docstrings in `duties.py`

### DIFF
--- a/duties.py
+++ b/duties.py
@@ -128,7 +128,7 @@ def check_quality(ctx: Context) -> None:
 
     ...where ID is the identifier of the rule you want to ignore for this line.
 
-    Examples:
+    Example:
         ```python title="src/your_package/module.py"
         import subprocess
         ```
@@ -220,7 +220,7 @@ def check_types(ctx: Context) -> None:
 
     ...where ID is the name of the warning.
 
-    Examples:
+    Example:
         ```python title="src/your_package/module.py"
         result = data_dict.get(key, None).value
         ```

--- a/duties.py
+++ b/duties.py
@@ -128,7 +128,7 @@ def check_quality(ctx: Context) -> None:
 
     ...where ID is the identifier of the rule you want to ignore for this line.
 
-    Example:
+    Examples:
         ```python title="src/your_package/module.py"
         import subprocess
         ```
@@ -220,7 +220,7 @@ def check_types(ctx: Context) -> None:
 
     ...where ID is the name of the warning.
 
-    Example:
+    Examples:
         ```python title="src/your_package/module.py"
         result = data_dict.get(key, None).value
         ```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -222,10 +222,8 @@ plugins:
         options:
           backlinks: tree
           docstring_options:
-            per_style_options:
-              google:
-                ignore_init_summary: true
-          docstring_style: auto
+            ignore_init_summary: true
+          docstring_style: google
           docstring_section_style: list
           extensions:
           - griffe_inherited_docstrings


### PR DESCRIPTION
### For reviewers
<!-- Help reviewers by letting them know whether AI was used to create this PR. -->

- [x] I did not use AI
- [ ] I used AI and thoroughly reviewed every code/docs change

### Description of the change

In the docstrings in `duties.py`, there are some `Example:` occurrences, but these should be `Examples:` (https://mkdocstrings.github.io/griffe/reference/docstrings/#google-section-examples). This issue causes broken document format (https://mkdocstrings.github.io/griffe/guide/contributors/commands/#check-quality, https://mkdocstrings.github.io/griffe/guide/contributors/commands/#check-types ).