### PR TITLE
docs: Fix `python` command to `python3` for compatibility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@
 default: help
 	@echo
 	@echo 'Enable direnv in your shell to use the `make` command: `direnv allow`'
-	@echo 'Or use `python scripts/make ARGS` to run the commands/tasks directly.'
+	@echo 'Or use `python3 scripts/make ARGS` to run the commands/tasks directly.'
 
 .DEFAULT_GOAL: default
 
@@ -32,4 +32,4 @@ actions = \
 
 .PHONY: $(actions)
 $(actions):
-	@python scripts/make "$@"
+	@python3 scripts/make "$@"

--- a/scripts/make.py
+++ b/scripts/make.py
@@ -146,7 +146,7 @@ def setup() -> None:
     print("Installing dependencies (default environment)")
     default_venv = Path(".venv")
     if not default_venv.exists():
-        _shell("uv venv --python python")
+        _shell("uv venv --python python3")
     _uv_install(default_venv)
 
     if PYTHON_VERSIONS:


### PR DESCRIPTION


### For reviewers
<!-- Help reviewers by letting them know whether AI was used to create this PR. -->

- [x] I did not use AI
- [ ] I used AI and thoroughly reviewed every code/docs change

### Description of the change
<!-- Quick sentence for small changes, longer description for more impacting changes. -->
The `python` command is not always available or guaranteed to point to `python3` depending on the environment. To ensure compatibility across different systems, this PR changes the hardcoded `python` command to `python3`, aligning with the shebang in the script.
