### PR TITLE
fix: render empty-tuple subscript annotation as tuple[()] not tuple[]

### DIFF
--- a/packages/griffelib/src/griffe/_internal/expressions.py
+++ b/packages/griffelib/src/griffe/_internal/expressions.py
@@ -1003,6 +1003,14 @@ class ExprTuple(Expr):
     """Whether the tuple is implicit (e.g. without parentheses in a subscript's slice)."""
 
     def iterate(self, *, flat: bool = True) -> Iterator[str | Expr]:
+        if self.implicit and not self.elements:
+            # An empty tuple is always written as `()` and cannot be implicit.
+            # This arises in annotations like `tuple[()]`, where the AST represents
+            # the subscript slice as an empty Tuple node, but the parentheses must
+            # be preserved to produce valid Python (`tuple[]` is a SyntaxError).
+            yield "("
+            yield ")"
+            return
         if not self.implicit:
             yield "("
         yield from _join(self.elements, ", ", flat=flat)

--- a/packages/griffelib/src/griffe/_internal/expressions.py
+++ b/packages/griffelib/src/griffe/_internal/expressions.py
@@ -1003,13 +1003,11 @@ class ExprTuple(Expr):
     """Whether the tuple is implicit (e.g. without parentheses in a subscript's slice)."""
 
     def iterate(self, *, flat: bool = True) -> Iterator[str | Expr]:
-        if self.implicit and not self.elements:
-            # An empty tuple is always written as `()` and cannot be implicit.
-            # This arises in annotations like `tuple[()]`, where the AST represents
-            # the subscript slice as an empty Tuple node, but the parentheses must
-            # be preserved to produce valid Python (`tuple[]` is a SyntaxError).
-            yield "("
-            yield ")"
+        # We fixed `_build_tuple` to make sure we never build
+        # implicit tuples with no elements, but since users might load
+        # data built with previous Griffe versions, we must be defensive here.
+        if not self.elements:
+            yield "()"
             return
         if not self.implicit:
             yield "("
@@ -1405,7 +1403,12 @@ def _build_tuple(
     compr_target: bool = False,
     **kwargs: Any,
 ) -> Expr:
-    return ExprTuple([_build(el, parent, **kwargs) for el in node.elts], implicit=subscript_slice or compr_target)
+    # An empty tuple is always written as `()` and cannot be implicit.
+    # This arises in annotations like `tuple[()]`, where the AST represents
+    # the subscript slice as an empty Tuple node, but the parentheses must
+    # be preserved to produce valid Python (`tuple[]` is a SyntaxError).
+    implicit = (subscript_slice or compr_target) if node.elts else False
+    return ExprTuple([_build(el, parent, **kwargs) for el in node.elts], implicit=implicit)
 
 
 def _build_unaryop(node: ast.UnaryOp, parent: Module | Class, **kwargs: Any) -> Expr:

--- a/packages/griffelib/tests/test_expressions.py
+++ b/packages/griffelib/tests/test_expressions.py
@@ -311,3 +311,22 @@ def test_render_dict_with_unpacking() -> None:
         assert str(module["a"].value) == "{**base, 'x': 1}"
         assert str(module["b"].value) == "{**d1, **d2}"
         assert str(module["c"].value) == "{None: 1, 'y': 2}"
+
+
+def test_empty_tuple_annotation_str() -> None:
+    """Check that empty-tuple annotations round-trip correctly.
+
+    ``tuple[()]`` is a valid annotation for a zero-element tuple.
+    Its string representation must remain ``tuple[()]``, not the
+    invalid ``tuple[]``.
+    """
+    with temporary_visited_module(
+        """
+        from typing import Tuple
+
+        def f1() -> tuple[()]: ...
+        def f2() -> Tuple[()]: ...
+        """,
+    ) as module:
+        assert str(module["f1"].returns) == "tuple[()]"
+        assert str(module["f2"].returns) == "Tuple[()]"

--- a/packages/griffelib/tests/test_expressions.py
+++ b/packages/griffelib/tests/test_expressions.py
@@ -316,9 +316,9 @@ def test_render_dict_with_unpacking() -> None:
 def test_empty_tuple_annotation_str() -> None:
     """Check that empty-tuple annotations round-trip correctly.
 
-    ``tuple[()]`` is a valid annotation for a zero-element tuple.
-    Its string representation must remain ``tuple[()]``, not the
-    invalid ``tuple[]``.
+    `tuple[()]` is a valid annotation for a zero-element tuple.
+    Its string representation must remain `tuple[()]`, not the
+    invalid `tuple[]`.
     """
     with temporary_visited_module(
         """
@@ -328,5 +328,7 @@ def test_empty_tuple_annotation_str() -> None:
         def f2() -> Tuple[()]: ...
         """,
     ) as module:
+        assert not module["f1"].returns.slice.implicit
+        assert not module["f2"].returns.slice.implicit
         assert str(module["f1"].returns) == "tuple[()]"
         assert str(module["f2"].returns) == "Tuple[()]"


### PR DESCRIPTION
### For reviewers
<!-- Help reviewers by letting them know whether AI was used to create this PR. -->

- [ ] I did not use AI
- [x] I used AI and thoroughly reviewed every code/docs change

### Description of the change
<!-- Quick sentence for small changes, longer description for more impacting changes. -->

Fix rendering for empty-tuple subscript annotations so `tuple[()]` and `Tuple[()]` stringify as valid Python instead of `tuple[]` / `Tuple[]`.

`tuple[()]` is a valid annotation for a zero-element tuple. Griffe parses it as an `ExprSubscript` whose slice is an implicit, empty `ExprTuple`. Because `ExprTuple.iterate()` suppressed parentheses when `implicit=True` and yielded no elements for an empty tuple, the outer subscript rendered empty brackets.

An empty tuple has no omitted source form; it must be written as `()`. This adds a focused early return for the empty implicit tuple case and covers both builtin `tuple` and `typing.Tuple` with `test_empty_tuple_annotation_str`.

Validation:

- Added `test_empty_tuple_annotation_str`.
- All 977 tests pass locally.

### Relevant resources
<!-- Link to any relevant GitHub issue, PR or discussion, section in online docs, etc. -->

- No linked issue.
