### PR TITLE
feat: Support Await expressions

### DIFF
--- a/packages/griffelib/src/griffe/__init__.py
+++ b/packages/griffelib/src/griffe/__init__.py
@@ -277,6 +277,7 @@ from griffe._internal.exceptions import (
 from griffe._internal.expressions import (
     Expr,
     ExprAttribute,
+    ExprAwait,
     ExprBinOp,
     ExprBoolOp,
     ExprCall,
@@ -433,6 +434,7 @@ __all__ = [
     "ExplanationStyle",
     "Expr",
     "ExprAttribute",
+    "ExprAwait",
     "ExprBinOp",
     "ExprBoolOp",
     "ExprCall",

--- a/packages/griffelib/src/griffe/_internal/expressions.py
+++ b/packages/griffelib/src/griffe/_internal/expressions.py
@@ -1045,6 +1045,18 @@ class ExprUnaryOp(Expr):
 
 
 @dataclass(eq=True, slots=True)
+class ExprAwait(Expr):
+    """Await expressions like `await call()`."""
+
+    value: str | Expr
+    """Awaited value."""
+
+    def iterate(self, *, flat: bool = True) -> Iterator[str | Expr]:
+        yield "await "
+        yield from _yield(self.value, flat=flat, outer_precedence=_OperatorPrecedence.CALL_ATTRIBUTE)
+
+
+@dataclass(eq=True, slots=True)
 class ExprYield(Expr):
     """Yield statements like `yield a`."""
 
@@ -1111,7 +1123,6 @@ _compare_op_map = {
     ast.NotIn: "not in",
 }
 
-# TODO: Support `ast.Await`.
 _precedence_map = {
     # Literals and names.
     ExprName: lambda _: _OperatorPrecedence.ATOMIC,
@@ -1130,6 +1141,7 @@ _precedence_map = {
     ExprAttribute: lambda _: _OperatorPrecedence.CALL_ATTRIBUTE,
     ExprSubscript: lambda _: _OperatorPrecedence.CALL_ATTRIBUTE,
     ExprCall: lambda _: _OperatorPrecedence.CALL_ATTRIBUTE,
+    ExprAwait: lambda _: _OperatorPrecedence.AWAIT,
     ExprUnaryOp: lambda e: {"not": _OperatorPrecedence.NOT}.get(e.operator, _OperatorPrecedence.POS_NEG_BIT_NOT),
     ExprBinOp: lambda e: {
         "**": _OperatorPrecedence.EXPONENT,
@@ -1181,6 +1193,10 @@ def _build_attribute(node: ast.Attribute, parent: Module | Class, **kwargs: Any)
     if isinstance(left, str):
         return ExprAttribute([left, ExprName(node.attr, "str")])
     return ExprAttribute([left, ExprName(node.attr)])
+
+
+def _build_await(node: ast.Await, parent: Module | Class, **kwargs: Any) -> Expr:
+    return ExprAwait(_build(node.value, parent, **kwargs))
 
 
 def _build_binop(node: ast.BinOp, parent: Module | Class, **kwargs: Any) -> Expr:
@@ -1433,6 +1449,7 @@ class _BuildCallable(Protocol):
 
 _node_map: dict[type, _BuildCallable] = {
     ast.Attribute: _build_attribute,
+    ast.Await: _build_await,
     ast.BinOp: _build_binop,
     ast.BoolOp: _build_boolop,
     ast.Call: _build_call,

--- a/packages/griffelib/tests/test_expressions.py
+++ b/packages/griffelib/tests/test_expressions.py
@@ -7,7 +7,7 @@ import sys
 
 import pytest
 
-from griffe import Module, Parser, get_expression, temporary_visited_module
+from griffe import ExprAwait, Module, Parser, get_expression, temporary_visited_module
 from tests.test_nodes import syntax_examples
 
 
@@ -86,6 +86,31 @@ def test_expressions(code: str) -> None:
     top_node = compile(code, filename="<>", mode="exec", flags=ast.PyCF_ONLY_AST, optimize=2)
     expression = get_expression(top_node.body[0].value, parent=Module("module"))  # ty:ignore[unresolved-attribute]
     assert str(expression) == code
+
+
+@pytest.mark.parametrize(
+    ("source", "expected"),
+    [
+        ("await dependency()", "await dependency()"),
+        ("(await dependency()).attr", "(await dependency()).attr"),
+        ("(await dependency())()", "(await dependency())()"),
+        ("await dependency() ** exponent", "await dependency() ** exponent"),
+        ("-await dependency()", "-await dependency()"),
+        ("await (dependency() ** exponent)", "await (dependency() ** exponent)"),
+        ("await (await dependency())", "await (await dependency())"),
+        ("await (left + right)", "await (left + right)"),
+    ],
+)
+def test_await_expression(source: str, expected: str) -> None:
+    """Build Await expressions with their correct precedence."""
+    node = ast.parse(source, mode="eval").body
+    expression = get_expression(node, parent=Module("module"))
+    rendered = str(expression)
+
+    if isinstance(node, ast.Await):
+        assert isinstance(expression, ExprAwait)
+    assert rendered == expected
+    assert ast.dump(ast.parse(rendered, mode="eval").body) == ast.dump(node)
 
 
 def test_length_one_tuple_as_string() -> None:


### PR DESCRIPTION
### For reviewers

- [ ] I did not use AI
- [x] I used AI and thoroughly reviewed every code/docs change

### Description of the change

`get_expression()` currently supports every concrete Python expression node except
`ast.Await`, which raises `KeyError`. This adds the missing expression model, builder,
precedence handling, public export, and an AST-equivalence matrix covering Await in its
precedence-sensitive contexts.

### Relevant resources

- https://docs.python.org/3/reference/expressions.html#await-expression
- https://docs.python.org/3/reference/expressions.html#operator-precedence
