### PR TITLE
fix: keep parentheses around top-level named expressions (walrus)

### DIFF
--- a/packages/griffelib/src/griffe/_internal/expressions.py
+++ b/packages/griffelib/src/griffe/_internal/expressions.py
@@ -164,7 +164,13 @@ class Expr:
     """Base class for expressions."""
 
     def __str__(self) -> str:
-        return "".join(elem if isinstance(elem, str) else elem.name for elem in self.iterate(flat=True))  # ty:ignore[unresolved-attribute]
+        rendered = "".join(elem if isinstance(elem, str) else elem.name for elem in self.iterate(flat=True))  # ty:ignore[unresolved-attribute]
+        # A top-level named expression (walrus) is invalid Python without surrounding
+        # parentheses, e.g. as an attribute value or a parameter default. Nested occurrences
+        # are parenthesized by their enclosing context, but the top level has none.
+        if isinstance(self, ExprNamedExpr):
+            return f"({rendered})"
+        return rendered
 
     def __iter__(self) -> Iterator[str | Expr]:
         """Iterate on the expression syntax and elements."""

--- a/packages/griffelib/tests/test_expressions.py
+++ b/packages/griffelib/tests/test_expressions.py
@@ -142,6 +142,7 @@ _expression_shapes = [
     "f'{x:>{width}}'",
 ]
 _expression_contexts = [
+    "%s",
     "f(%s)",
     "f(%s, 1)",
     "f(a=%s)",
@@ -197,6 +198,18 @@ def test_length_one_tuple_as_string() -> None:
     code = "x = ('a',)"
     with temporary_visited_module(code) as module:
         assert str(module["x"].value) == "('a',)"
+
+
+def test_top_level_named_expression_keeps_parentheses() -> None:
+    """A top-level named expression (walrus) must keep its surrounding parentheses.
+
+    Without them, the rendered string is invalid Python as an attribute value
+    or a parameter default (e.g. `x = n := 1` is a syntax error).
+    """
+    code = "x = (n := 1)\ndef f(a=(b := compute())): ...\n"
+    with temporary_visited_module(code) as module:
+        assert str(module["x"].value) == "(n := 1)"
+        assert str(module["f"].parameters["a"].default) == "(b := compute())"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### The bug

A top-level named expression (walrus, `:=`) — extracted as a whole attribute value or parameter default — is rendered **without** its surrounding parentheses, producing invalid Python:

```python
import griffe
# module: x = (n := 1); def f(a=(b := compute())): ...
m = griffe.load("mod")
str(m["x"].value)                    # 'n := 1'         -> `x = n := 1` is a SyntaxError
str(m["f"].parameters["a"].default)  # 'b := compute()' -> invalid as a default
```

`ast.unparse` (the authoritative "valid, faithful Python" renderer) always parenthesizes a `NamedExpr` here → `'(n := 1)'`. Griffe drops the parens only at the top level.

### Root cause

`Expr.__str__` (`packages/griffelib/src/griffe/_internal/expressions.py`) renders the top expression by iterating flatly, which bypasses the `_yield`/precedence logic that adds walrus parentheses in nested positions. `ExprNamedExpr` deliberately does not self-parenthesize (that would double-wrap when nested), and a top-level expression has no enclosing context to add them — so a standalone walrus never gets parenthesized.

This is exactly the gap left by commit `eb85f0d` ("Make stringified expressions valid and faithful Python"): its property test `test_expressions_stay_valid_and_equivalent` embeds `(w := 1)` in ~26 contexts, but every one **wraps** the expression — none renders it standalone.

### The fix

Wrap a top-level `ExprNamedExpr` in parentheses in `__str__`, matching `ast.unparse`. Nested walruses are still parenthesized by their enclosing context (not by `__str__`), so there is no double-wrapping.

### Verification

- The repro now renders `(n := 1)` and `(b := compute())`; nested cases are unchanged (`{'a': (w := 1)}`, `foo(k := 2)` — single parens / valid).
- Added `"%s"` (the standalone context) to the `_expression_contexts` property test — on `main` it fails on exactly `[%s-(w := 1)]` and nothing else — plus an explicit `test_top_level_named_expression_keeps_parentheses`.
- `tests/test_expressions.py` → 910 passed / 16 skipped; `tests/test_nodes.py` → 141 passed. No regression.

Reachability: `X = (n := compute())` (module/class attribute via walrus) and the shared-mutable-default idiom `def f(cache=(_cache := {}))` are ordinary user code; mkdocstrings renders these extracted strings straight into signatures/attribute docs, so the invalid output is user-visible.

Not a duplicate — the only related history, closed #152, is a different build-time `KeyError` for a walrus in a comprehension; no open issue/PR concerns top-level walrus rendering.

---

This PR was authored by an AI coding agent (Claude Code) running on this account: the AI found the bug, ran the repro, wrote the test, and wrote this description. The human account holder reviews every change and is accountable for it. The verification above is real and re-runnable from the diff. If this isn't the kind of contribution you want, say so and I'll close it.
