### PR TITLE
fix: Skip tests when running without dependencies from the root (griffe)

### DIFF
--- a/packages/griffelib/pyproject.toml
+++ b/packages/griffelib/pyproject.toml
@@ -41,6 +41,9 @@ classifiers = [
 # to download and inspect packages from PyPI.
 pypi = ["pip>=24.0", "platformdirs>=4.2", "wheel>=0.42"]
 
+[dependency-groups]
+dev = ["pytest>=8.2", "pytest-gitconfig>=0.8.0", "jsonschema>=4.18"]
+
 [tool.uv-dynamic-versioning]
 pattern = '(?P<base>\d+\.\d+\.\d+)'
 

--- a/packages/griffelib/tests/test_api.py
+++ b/packages/griffelib/tests/test_api.py
@@ -24,25 +24,33 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 import pytest
-from mkdocstrings import Inventory
 
 import griffe
-import griffecli
+
+try:
+    import griffecli
+except ModuleNotFoundError:
+    griffecli = None
 
 if TYPE_CHECKING:
     from collections.abc import Iterable, Iterator
     from types import ModuleType
 
+    from mkdocstrings import Inventory
 
-TESTED_MODULES = (griffe, griffecli)
+
+TESTED_MODULES = (griffe, griffecli) if griffecli else (griffe,)
 _test_all_modules = pytest.mark.parametrize("tested_module", TESTED_MODULES)
 
 
 @pytest.fixture(name="inventory", scope="module")
 def _fixture_inventory() -> Inventory:
+    pytest.importorskip("mkdocstrings")
     inventory_file = Path(__file__).parent.parent / "site" / "objects.inv"
     if not inventory_file.exists():
         pytest.skip("The objects inventory is not available.")
+    from mkdocstrings import Inventory
+
     with inventory_file.open("rb") as file:
         return Inventory.parse_sphinx(file)
 

--- a/packages/griffelib/tests/test_api.py
+++ b/packages/griffelib/tests/test_api.py
@@ -55,11 +55,15 @@ def _fixture_inventory() -> Inventory:
 
 
 def _load_modules(*modules: ModuleType) -> griffe.GriffeLoader:
+    extensions = ["unpack_typeddict"]
+    try:
+        import griffe_inherited_docstrings  # noqa: F401, PLC0415
+
+        extensions.append("griffe_inherited_docstrings")
+    except ImportError:
+        pass
     loader = griffe.GriffeLoader(
-        extensions=griffe.load_extensions(
-            "griffe_inherited_docstrings",
-            "unpack_typeddict",
-        ),
+        extensions=griffe.load_extensions(*extensions),
     )
     for module in modules:
         loader.load(module.__name__)

--- a/packages/griffelib/tests/test_api.py
+++ b/packages/griffelib/tests/test_api.py
@@ -45,14 +45,13 @@ _test_all_modules = pytest.mark.parametrize("tested_module", TESTED_MODULES)
 
 @pytest.fixture(name="inventory", scope="module")
 def _fixture_inventory() -> Inventory:
-    pytest.importorskip("mkdocstrings")
+    mkdocstrings = pytest.importorskip("mkdocstrings")
     inventory_file = Path(__file__).parent.parent / "site" / "objects.inv"
     if not inventory_file.exists():
         pytest.skip("The objects inventory is not available.")
-    from mkdocstrings import Inventory
 
     with inventory_file.open("rb") as file:
-        return Inventory.parse_sphinx(file)
+        return mkdocstrings.Inventory.parse_sphinx(file)
 
 
 def _load_modules(*modules: ModuleType) -> griffe.GriffeLoader:

--- a/packages/griffelib/tests/test_git.py
+++ b/packages/griffelib/tests/test_git.py
@@ -24,7 +24,7 @@ from typing import TYPE_CHECKING
 
 import pytest
 
-from griffe import Module, check, load_git
+from griffe import Module, load_git
 from tests import FIXTURES_DIR
 
 if TYPE_CHECKING:
@@ -117,4 +117,7 @@ def test_load_git_errors(git_repo: Path) -> None:
 
 def test_git_failures(tmp_path: Path) -> None:
     """Test failures to use Git."""
+    pytest.importorskip("griffecli")
+    from griffe import check
+
     assert check(tmp_path) == 2

--- a/packages/griffelib/tests/test_git.py
+++ b/packages/griffelib/tests/test_git.py
@@ -118,6 +118,6 @@ def test_load_git_errors(git_repo: Path) -> None:
 def test_git_failures(tmp_path: Path) -> None:
     """Test failures to use Git."""
     pytest.importorskip("griffecli")
-    from griffe import check
+    from griffe import check  # noqa: PLC0415
 
     assert check(tmp_path) == 2


### PR DESCRIPTION
### For reviewers
<!-- Help reviewers by letting them know whether AI was used to create this PR. -->

- [x] I did not use AI
- [ ] I used AI and thoroughly reviewed every code/docs change

### Description of the change

When running tests within `griffelib` alone as root, importing `griffecli` and `mkdocstrings` at module level causes `ModuleNotFoundError`. Defer these imports and guard them with `pytest.importorskip()` so the tests skip gracefully instead of failing.

Introducing those two dependencies to `griffelib` to just being able to run these tests does not seem like a reasonable choice. Therefore, the best solution I can think of is to gracefully bypass those tests.

I can also bypass those tests by manually skip them while running pytest but I feel like the tests come with the package should be error-free.

### Relevant resources

- #484 
