### PR TITLE
fix: preserve nested f-string format specs

### DIFF
--- a/packages/griffelib/src/griffe/_internal/expressions.py
+++ b/packages/griffelib/src/griffe/_internal/expressions.py
@@ -531,10 +531,11 @@ def _iterate_format_parts(
     format_spec: Sequence[str | Expr] | None,
     *,
     flat: bool = True,
+    separate_braces: bool = True,
 ) -> Iterator[str | Expr]:
     # Shared by `ExprFormatted` and `ExprInterpolation`.
     yield "{"
-    if str(value).startswith("{"):
+    if separate_braces and str(value).startswith("{"):
         # Separate braces, `{{` would be read as an escaped brace, e.g. `f"{ {1: 2}}"`.
         yield " "
     # Lambdas and walrus assignments need parentheses:
@@ -548,6 +549,16 @@ def _iterate_format_parts(
             if isinstance(part, str):
                 # Literal braces must be doubled, as in literal f-string parts.
                 yield part.replace("{", "{{").replace("}", "}}")
+            elif flat and isinstance(part, (ExprFormatted, ExprInterpolation)):
+                # Nested format fields already have their own braces; adding a separating
+                # space here changes the JoinedStr shape when their value starts with `{`.
+                yield from _iterate_format_parts(
+                    part.value,
+                    part.conversion,
+                    part.format_spec,
+                    flat=True,
+                    separate_braces=False,
+                )
             else:
                 yield from _yield(part, flat=flat, outer_precedence=_OperatorPrecedence.NONE)
     yield "}"

--- a/packages/griffelib/tests/test_expressions.py
+++ b/packages/griffelib/tests/test_expressions.py
@@ -208,6 +208,16 @@ def test_expressions_stay_valid_and_equivalent(shape: str, context: str) -> None
     assert ast.dump(reparsed) == ast.dump(original), f"{code!r} rendered as {rendered!r}"
 
 
+def test_nested_container_format_spec_is_roundtrip_safe() -> None:
+    """Container replacement fields in format specs must preserve the source AST."""
+    code = "f'{value:{{1, 2}}}'"
+    original = ast.parse(code, mode="eval")
+    expression = get_expression(original.body, parent=Module("module"), parse_strings=False)
+    rendered = str(expression)
+    reparsed = ast.parse(rendered, mode="eval")
+    assert ast.dump(reparsed) == ast.dump(original), f"{code!r} rendered as {rendered!r}"
+
+
 def test_length_one_tuple_as_string() -> None:
     """Length-1 tuples must have a trailing comma."""
     code = "x = ('a',)"


### PR DESCRIPTION
### For reviewers
<!-- Help reviewers by letting them know whether AI was used to create this PR. -->

- [ ] I did not use AI
- [x] I used AI and thoroughly reviewed every code/docs change

### Description of the change

`str(Expr)` added a separating space when a container expression was nested in an f-string format specification. For example, `f'{value:{{1, 2}}}'` was rendered as `f'{value:{ {1, 2}}}'`, which does not preserve the source AST’s format-spec segments. The fix keeps the separator for ordinary replacement fields but suppresses it for nested format fields, and adds a focused regression test.

Validation on Python 3.12:

- `PYTHON_VERSIONS='' ./scripts/make test`
- `PYTHON_VERSIONS='' ./scripts/make check`
- `UV_PROJECT_ENVIRONMENT=.venv uv run --no-sync uv build --all`

### Relevant resources

- Independent reproduction on the current default branch; no exact open issue was found.
- https://github.com/mkdocstrings/griffe/pull/478
- https://docs.python.org/3/library/ast.html#ast.unparse
