### PR TITLE
fix: Preserve standalone named expression parentheses

### DIFF
--- a/packages/griffelib/src/griffe/_internal/expressions.py
+++ b/packages/griffelib/src/griffe/_internal/expressions.py
@@ -952,6 +952,9 @@ class ExprNamedExpr(Expr):
     value: str | Expr
     """Value."""
 
+    def __str__(self) -> str:
+        return f"({Expr.__str__(self)})"
+
     def iterate(self, *, flat: bool = True) -> Iterator[str | Expr]:
         yield from _yield(self.target, flat=flat, outer_precedence=_OperatorPrecedence.NONE)
         yield " := "

--- a/packages/griffelib/tests/test_expressions.py
+++ b/packages/griffelib/tests/test_expressions.py
@@ -218,6 +218,16 @@ def test_nested_container_format_spec_is_roundtrip_safe() -> None:
     assert ast.dump(reparsed) == ast.dump(original), f"{code!r} rendered as {rendered!r}"
 
 
+def test_standalone_named_expression_is_roundtrip_safe() -> None:
+    """Standalone named expressions must retain their required parentheses."""
+    code = "(value := 1)"
+    original = ast.parse(code, mode="eval")
+    expression = get_expression(original.body, parent=Module("module"), parse_strings=False)
+    rendered = str(expression)
+    reparsed = ast.parse(rendered, mode="eval")
+    assert ast.dump(reparsed) == ast.dump(original), f"{code!r} rendered as {rendered!r}"
+
+
 @pytest.mark.parametrize(
     "code",
     [


### PR DESCRIPTION
### For reviewers

- [ ] I did not use AI
- [x] I used AI and thoroughly reviewed every code/docs change

### Description of the change

Preserve the required parentheses when a named expression is rendered on its own. Previously, `(value := 1)` became `value := 1`, which cannot be parsed as an expression.

Nested named expressions keep using the existing context-aware renderer, so their output is unchanged.

### Relevant resources

- Reproduced independently on the current `main` branch.
- `PYTHON_VERSIONS='' ./scripts/make check test`
- `.venv/bin/python -m pytest packages/griffelib/tests/test_expressions.py -q` — 918 passed, 16 skipped
